### PR TITLE
Add remote presentation control feature

### DIFF
--- a/GospelPresenter/GospelPresenter.Shared/Components/Dashboard.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Dashboard.razor
@@ -22,6 +22,31 @@
         }
     </div>
 
+    @if (liveSessionId is not null)
+    {
+        var liveSession = SharedAppState.GetActiveSession(liveSessionId);
+        var livePresentationId = liveSession?.PresentationId;
+        var livePresentationName = liveSession?.PresentationName;
+        <div class="bg-emerald-50 dark:bg-emerald-900/20 rounded-xl border border-emerald-200 dark:border-emerald-800 overflow-hidden">
+            <div class="px-4 py-3 flex items-center justify-between gap-3">
+                <div class="flex items-center gap-2 min-w-0">
+                    <span class="inline-block size-2 rounded-full bg-emerald-500 shrink-0 animate-pulse"></span>
+                    <div class="min-w-0">
+                        <div class="text-xs font-semibold uppercase tracking-widest text-emerald-600 dark:text-emerald-400">@L["Dashboard.LiveNow"]</div>
+                        <div class="text-sm font-medium text-neutral-700 dark:text-neutral-200 truncate">@(livePresentationName ?? L["Dashboard.LiveNowUnknown"])</div>
+                    </div>
+                </div>
+                @if (livePresentationId is not null)
+                {
+                    <a href="/presentations/@livePresentationId?remote=true"
+                       class="shrink-0 px-3 py-1.5 rounded-lg bg-emerald-500 text-white text-xs font-medium hover:bg-emerald-600 no-underline">
+                        @L["Dashboard.TakeControl"]
+                    </a>
+                }
+            </div>
+        </div>
+    }
+
     @if (dashboard is null)
     {
         <div class="bg-neutral-50 dark:bg-neutral-800 dark:text-neutral-100 rounded-xl shadow-sm border-t-[0.5px] border-white dark:border-neutral-700 overflow-hidden">
@@ -147,9 +172,23 @@
 
     private bool hasAny => dashboard is { } d && (d.Today.Count + d.Upcoming.Count + d.Previous.Count) > 0;
 
+    private string? liveSessionId
+    {
+        get
+        {
+            var orgId = OrgState.ActiveOrganizationId;
+            if (orgId is null) return null;
+            var sessionId = SharedAppState.GetActiveSessionIdForOrganization(orgId);
+            if (sessionId is null || !SharedAppState.IsRemoteControlEnabled(sessionId)) return null;
+            return sessionId;
+        }
+    }
+
     protected override async Task OnInitializedAsync()
     {
         SharedAppState.PropertyChanged += OnSharedStateChanged;
+        SharedAppState.PresentationActivated += OnPresentationActivatedOrDeactivated;
+        SharedAppState.PresentationDeactivated += OnPresentationActivatedOrDeactivated;
 
         var orgId = OrgState.ActiveOrganizationId;
         if (orgId is null) return;
@@ -258,12 +297,18 @@
 
     private void OnSharedStateChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == AppState.SessionId)
-            _ = InvokeAsync(StateHasChanged);
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void OnPresentationActivatedOrDeactivated(string sessionId)
+    {
+        _ = InvokeAsync(StateHasChanged);
     }
 
     public void Dispose()
     {
         SharedAppState.PropertyChanged -= OnSharedStateChanged;
+        SharedAppState.PresentationActivated -= OnPresentationActivatedOrDeactivated;
+        SharedAppState.PresentationDeactivated -= OnPresentationActivatedOrDeactivated;
     }
 }

--- a/GospelPresenter/GospelPresenter.Shared/Components/Presentations/LivePanel.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Presentations/LivePanel.razor
@@ -177,18 +177,21 @@
 @if (SessionId is not null)
 {
     var isRemoteEnabled = SharedAppState.IsRemoteControlEnabled(SessionId);
-    <button @onclick="ToggleRemoteControl"
-            class="cursor-pointer flex items-center justify-between gap-2 px-3 py-2 rounded-lg text-sm @(isRemoteEnabled ? "text-neutral-600 dark:text-neutral-300 bg-sky-100 dark:bg-sky-900/30 ring-1 ring-sky-500" : "text-neutral-600 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700/50")">
-        <div class="flex items-center gap-2">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 shrink-0">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0H3"/>
-            </svg>
-            <span>@L["LivePanel.RemoteControl"]</span>
-        </div>
-        <div class="pointer-events-none">
-            <ToggleSwitch Value="@isRemoteEnabled"/>
-        </div>
-    </button>
+    @if (!IsRemoteController)
+    {
+        <button @onclick="ToggleRemoteControl"
+                class="cursor-pointer flex items-center justify-between gap-2 px-3 py-2 rounded-lg text-sm @(isRemoteEnabled ? "text-neutral-600 dark:text-neutral-300 bg-sky-100 dark:bg-sky-900/30 ring-1 ring-sky-500" : "text-neutral-600 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700/50")">
+            <div class="flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 shrink-0">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0H3"/>
+                </svg>
+                <span>@L["LivePanel.RemoteControl"]</span>
+            </div>
+            <div class="pointer-events-none">
+                <ToggleSwitch Value="@isRemoteEnabled"/>
+            </div>
+        </button>
+    }
 }
 
 @if (ShowGrow)
@@ -223,6 +226,7 @@
     [Parameter] public EventCallback OnStopPresentation { get; set; }
     [Parameter] public bool ShowGrow { get; set; }
     [Parameter] public string? SessionId { get; set; }
+    [Parameter] public bool IsRemoteController { get; set; }
     [Parameter] public List<RemoteDisplay> SavedDisplays { get; set; } = [];
 
     private HashSet<string> savedDisplayIds => SavedDisplays.Select(d => d.DisplayIdentifier).ToHashSet();

--- a/GospelPresenter/GospelPresenter.Shared/Components/Presentations/LivePanel.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Presentations/LivePanel.razor
@@ -4,6 +4,7 @@
 @implements IDisposable
 
 @inject RemoteDisplayState RemoteDisplayState
+@inject SharedAppState SharedAppState
 @inject IJSRuntime JsRuntime
 
 @{
@@ -171,6 +172,23 @@
             </button>
         </Menu>
     </Dropdown>
+}
+
+@if (SessionId is not null)
+{
+    var isRemoteEnabled = SharedAppState.IsRemoteControlEnabled(SessionId);
+    <button @onclick="ToggleRemoteControl"
+            class="cursor-pointer flex items-center justify-between gap-2 px-3 py-2 rounded-lg text-sm @(isRemoteEnabled ? "text-neutral-600 dark:text-neutral-300 bg-sky-100 dark:bg-sky-900/30 ring-1 ring-sky-500" : "text-neutral-600 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700/50")">
+        <div class="flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 shrink-0">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0H3"/>
+            </svg>
+            <span>@L["LivePanel.RemoteControl"]</span>
+        </div>
+        <div class="pointer-events-none">
+            <ToggleSwitch Value="@isRemoteEnabled"/>
+        </div>
+    </button>
 }
 
 @if (ShowGrow)
@@ -435,4 +453,13 @@
     private void ShowPairingDialog() => showPairingDialog = true;
 
     private void ClosePairingDialog() => showPairingDialog = false;
+
+    private void ToggleRemoteControl()
+    {
+        if (SessionId is null) return;
+        if (SharedAppState.IsRemoteControlEnabled(SessionId))
+            SharedAppState.DisableRemoteControl(SessionId);
+        else
+            SharedAppState.EnableRemoteControl(SessionId);
+    }
 }

--- a/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
@@ -393,6 +393,7 @@
                                 OverlaySlides="@overlaySlides"
                                 ActiveOverlayId="@activeOverlayId"
                                 SessionId="@EffectiveSessionId"
+                                IsRemoteController="@IsRemoteMode"
                                 SavedDisplays="@savedDisplays"
                                 OnClearSlide="() => SharedAppState.ToggleBlackScreen(EffectiveSessionId)"
                                 OnToggleOverlay="ToggleOverlay"
@@ -418,6 +419,7 @@
                             OverlaySlides="@overlaySlides"
                             ActiveOverlayId="@activeOverlayId"
                             SessionId="@EffectiveSessionId"
+                            IsRemoteController="@IsRemoteMode"
                             SavedDisplays="@savedDisplays"
                             ShowGrow
                             OnClearSlide="() => SharedAppState.ToggleBlackScreen(EffectiveSessionId)"

--- a/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
@@ -32,14 +32,20 @@
 @{
     var statusBarHeight = StatusBarService.GetStatusBarHeight();
     var statusBarStyle = $"padding-top: {statusBarHeight}px";
-    var liveSlide = SharedAppState.GetLiveSlide(AppState.SessionId);
-    var isLiveShowing = SharedAppState.IsPresentationActive(AppState.SessionId) && liveSlide.Status != LiveSlideStatus.ShowingBlackScreen;
+    var liveSlide = SharedAppState.GetLiveSlide(EffectiveSessionId);
+    var isLiveShowing = SharedAppState.IsPresentationActive(EffectiveSessionId) && liveSlide.Status != LiveSlideStatus.ShowingBlackScreen;
 }
 <div class="flex flex-col h-full relative dark:text-neutral-200 dark:bg-neutral-800" style="@statusBarStyle">
     @if (IsTemplateMode)
     {
         <div class="bg-sky-500 text-white text-center py-1.5 text-sm font-medium shrink-0">
             @L["Templates.EditingBanner"]
+        </div>
+    }
+    @if (IsRemoteMode)
+    {
+        <div class="bg-amber-500 text-white text-center py-1.5 text-sm font-medium shrink-0">
+            @L["RemoteControl.Banner"]
         </div>
     }
     <div class="flex flex-1 min-h-0 relative">
@@ -131,7 +137,7 @@
                     </div>
 
                     <div class="p-3 hidden lg:flex items-center gap-2">
-                        @if (!IsTemplateMode && !SharedAppState.IsPresentationActive(AppState.SessionId))
+                        @if (!IsTemplateMode && !IsRemoteMode && !SharedAppState.IsPresentationActive(AppState.SessionId))
                         {
                             <button @onclick="StartPresentation"
                                     class="px-4 py-2.5 rounded-full flex items-center gap-2 shadow-lg cursor-pointer pointer-events-auto bg-emerald-500 text-white hover:bg-emerald-600"
@@ -167,8 +173,20 @@
                     var mainClass = hasSlides
                         ? "mx-auto sm:mx-0 grid grid-cols-1 sm:flex sm:flex-wrap gap-3 p-3 overflow-auto pt-16 pb-36"
                         : "flex items-center justify-center h-full overflow-auto";
+                    var remoteNotReady = IsRemoteMode && !IsRemoteReady;
+                    var remoteNoSession = IsRemoteMode && _presenterSessionId is null;
                 }
-                @if (SelectedAudio is not null)
+                @if (remoteNotReady)
+                {
+                    <div class="flex items-center justify-center h-full text-center px-6 pt-16">
+                        <div class="space-y-2">
+                            <div class="text-neutral-400 dark:text-neutral-500 text-sm">
+                                @(remoteNoSession ? L["RemoteControl.NoActivePresentation"] : L["RemoteControl.NotEnabled"])
+                            </div>
+                        </div>
+                    </div>
+                }
+                else if (SelectedAudio is not null)
                 {
                     <div id="audio-container" class="flex flex-col gap-3 w-full sm:max-w-lg sm:mx-auto px-3 pt-16 overflow-auto">
                         @for (var i = 0; i < SelectedAudio.Parts.Count; i++)
@@ -347,7 +365,7 @@
                         <MenuToggleButton OnClick="() => AppState.IsMenuVisible = true"/>
                     </div>
 
-                    @if (!IsTemplateMode && !SharedAppState.IsPresentationActive(AppState.SessionId))
+                    @if (!IsTemplateMode && !IsRemoteMode && !SharedAppState.IsPresentationActive(AppState.SessionId))
                     {
                         <div class="lg:hidden pointer-events-auto">
                             <button @onclick="StartPresentation"
@@ -361,9 +379,9 @@
                         </div>
                     }
 
-                    @if (!IsTemplateMode && SharedAppState.IsPresentationActive(AppState.SessionId))
+                    @if (!IsTemplateMode && IsRemoteReady && SharedAppState.IsPresentationActive(EffectiveSessionId))
                     {
-                        var activeOverlay = SharedAppState.GetActiveOverlay(AppState.SessionId);
+                        var activeOverlay = SharedAppState.GetActiveOverlay(EffectiveSessionId);
 
                         <div class="pointer-events-auto ml-auto lg:hidden bg-white/90 dark:bg-neutral-800/90 backdrop-blur-sm rounded-2xl shadow-xl p-4 flex flex-col gap-3">
                             <LivePanel
@@ -374,9 +392,9 @@
                                 BaseHeight="@AppState.BaseSlideHeight"
                                 OverlaySlides="@overlaySlides"
                                 ActiveOverlayId="@activeOverlayId"
-                                SessionId="@AppState.SessionId"
+                                SessionId="@EffectiveSessionId"
                                 SavedDisplays="@savedDisplays"
-                                OnClearSlide="() => SharedAppState.ToggleBlackScreen(AppState.SessionId)"
+                                OnClearSlide="() => SharedAppState.ToggleBlackScreen(EffectiveSessionId)"
                                 OnToggleOverlay="ToggleOverlay"
                                 OnStopPresentation="StopPresentation"/>
                         </div>
@@ -385,9 +403,9 @@
 
             </div>
 
-            @if (!IsTemplateMode && SharedAppState.IsPresentationActive(AppState.SessionId))
+            @if (!IsTemplateMode && IsRemoteReady && SharedAppState.IsPresentationActive(EffectiveSessionId))
             {
-                var activeOverlayDesktop = SharedAppState.GetActiveOverlay(AppState.SessionId);
+                var activeOverlayDesktop = SharedAppState.GetActiveOverlay(EffectiveSessionId);
 
                 <div class="hidden lg:flex flex-col shrink-0 w-72 h-full bg-white dark:bg-neutral-800 overflow-auto shadow-xl">
                     <div class="p-4 flex flex-col gap-3 h-full">
@@ -399,10 +417,10 @@
                             BaseHeight="@AppState.BaseSlideHeight"
                             OverlaySlides="@overlaySlides"
                             ActiveOverlayId="@activeOverlayId"
-                            SessionId="@AppState.SessionId"
+                            SessionId="@EffectiveSessionId"
                             SavedDisplays="@savedDisplays"
                             ShowGrow
-                            OnClearSlide="() => SharedAppState.ToggleBlackScreen(AppState.SessionId)"
+                            OnClearSlide="() => SharedAppState.ToggleBlackScreen(EffectiveSessionId)"
                             OnToggleOverlay="ToggleOverlay"
                             OnStopPresentation="StopPresentation"/>
                     </div>
@@ -576,8 +594,18 @@
     [Parameter] public string? PresentationId { get; set; }
     [Parameter] public string? TemplateId { get; set; }
 
+    [SupplyParameterFromQuery(Name = "remote")]
+    public bool Remote { get; set; }
+
     private bool IsTemplateMode => TemplateId is not null;
+    private bool IsRemoteMode => Remote && !IsTemplateMode;
     private string? EffectiveId => TemplateId ?? PresentationId;
+
+    private string? _presenterSessionId;
+    private string EffectiveSessionId =>
+        IsRemoteMode && _presenterSessionId is not null ? _presenterSessionId : AppState.SessionId;
+    private bool IsRemoteReady => !IsRemoteMode ||
+        (_presenterSessionId is not null && SharedAppState.IsRemoteControlEnabled(_presenterSessionId));
 
     private string? loadedPresentationId;
     private Models.Presentation? loadedPresentation;
@@ -714,15 +742,15 @@
 
     private async Task StopPresentation()
     {
-        await JsRuntime.InvokeVoidAsync("stopLivePresentation", AppState.SessionId);
+        await JsRuntime.InvokeVoidAsync("stopLivePresentation", EffectiveSessionId);
         ResetLiveSlide();
-        SharedAppState.DeactivatePresentation(AppState.SessionId);
+        SharedAppState.DeactivatePresentation(EffectiveSessionId);
     }
 
     private void ResetLiveSlide()
     {
-        var current = SharedAppState.GetLiveSlide(AppState.SessionId);
-        SharedAppState.SetLiveSlide(AppState.SessionId, current with
+        var current = SharedAppState.GetLiveSlide(EffectiveSessionId);
+        SharedAppState.SetLiveSlide(EffectiveSessionId, current with
         {
             Status = LiveSlideStatus.ShowingBlackScreen
         });
@@ -966,10 +994,19 @@
         SharedAppState.PropertyChanged += OnPropertyChanged;
         SharedAppState.PresentationChanged += OnPresentationChanged;
         SharedAppState.OrganizationSlideStylesChanged += OnSlideStylesChanged;
+        SharedAppState.PresentationDeactivated += OnPresenterDeactivated;
     }
 
     protected override async Task OnParametersSetAsync()
     {
+        if (IsRemoteMode)
+        {
+            var orgId = OrgState.ActiveOrganizationId;
+            _presenterSessionId = orgId is not null
+                ? SharedAppState.GetActiveSessionIdForOrganization(orgId)
+                : null;
+        }
+
         if (EffectiveId == loadedPresentationId) return;
         loadedPresentationId = EffectiveId;
 
@@ -1052,7 +1089,7 @@
             savedDisplays = await RemoteDisplayService.GetDisplaysAsync(loadedPresentation.OrganizationId, OrgState.ToCallerContext());
         }
 
-        var liveItemId = SharedAppState.GetLiveSlide(AppState.SessionId).ProjectItemId;
+        var liveItemId = SharedAppState.GetLiveSlide(EffectiveSessionId).ProjectItemId;
         var activeItem = liveItemId is not null
             ? AppState.SelectedProject.Items.FirstOrDefault(x => x.Id == liveItemId)
             : null;
@@ -1109,7 +1146,17 @@
         SharedAppState.PropertyChanged -= OnPropertyChanged;
         SharedAppState.PresentationChanged -= OnPresentationChanged;
         SharedAppState.OrganizationSlideStylesChanged -= OnSlideStylesChanged;
+        SharedAppState.PresentationDeactivated -= OnPresenterDeactivated;
         dotNetRef?.Dispose();
+    }
+
+    private void OnPresenterDeactivated(string sessionId)
+    {
+        if (IsRemoteMode && sessionId == _presenterSessionId)
+        {
+            _presenterSessionId = null;
+            _ = InvokeAsync(StateHasChanged);
+        }
     }
 
     private void OnSlideStylesChanged(
@@ -1125,8 +1172,8 @@
         bibleStyle = newBibleStyle;
         bibleCreditsStyle = newBibleCreditsStyle;
 
-        var current = SharedAppState.GetLiveSlide(AppState.SessionId);
-        SharedAppState.SetLiveSlide(AppState.SessionId, current with
+        var current = SharedAppState.GetLiveSlide(EffectiveSessionId);
+        SharedAppState.SetLiveSlide(EffectiveSessionId, current with
         {
             SongStyle = newSongStyle,
             CreditsStyle = newCreditsStyle,
@@ -1172,6 +1219,10 @@
                 SharedAppState.ClearSessionExpired(AppState.SessionId);
             }
 
+            _ = InvokeAsync(StateHasChanged);
+        }
+        else if (sender is SharedAppState && IsRemoteMode && e.PropertyName == _presenterSessionId)
+        {
             _ = InvokeAsync(StateHasChanged);
         }
     }
@@ -1324,7 +1375,7 @@
                 var parts = imageItem?.Parts.OrderBy(p => p.SortOrder).ToList();
                 if (parts is not null && partIndex < parts.Count)
                 {
-                    imageUrl = ImageUrlHelper.LiveOrgImageUrl(AppState.SessionId, parts[partIndex].Content, "full");
+                    imageUrl = ImageUrlHelper.LiveOrgImageUrl(EffectiveSessionId, parts[partIndex].Content, "full");
                 }
 
                 break;
@@ -1351,7 +1402,7 @@
                     var orderedParts = slidesPresItem.Parts.OrderBy(p => p.SortOrder).ToList();
                     if (partIndex < orderedParts.Count && int.TryParse(orderedParts[partIndex].Content, out var pageIndex))
                     {
-                        imageUrl = ImageUrlHelper.LiveSlidesPageUrl(AppState.SessionId, slidesSourceId, pageIndex);
+                        imageUrl = ImageUrlHelper.LiveSlidesPageUrl(EffectiveSessionId, slidesSourceId, pageIndex);
                     }
                 }
                 break;
@@ -1361,9 +1412,9 @@
         }
 
         if (EffectiveId is not null)
-            SharedAppState.UpdateActivePresentationId(AppState.SessionId, EffectiveId, AppState.SelectedProject?.Name);
+            SharedAppState.UpdateActivePresentationId(EffectiveSessionId, EffectiveId, AppState.SelectedProject?.Name);
 
-        SharedAppState.SetLiveSlide(AppState.SessionId, SharedAppState.GetLiveSlide(AppState.SessionId) with
+        SharedAppState.SetLiveSlide(EffectiveSessionId, SharedAppState.GetLiveSlide(EffectiveSessionId) with
         {
             Status = LiveSlideStatus.ShowingPresentation,
             ItemType = projectItem.Type,
@@ -1398,7 +1449,7 @@
         if (activeOverlayId == overlay.Id)
         {
             activeOverlayId = null;
-            SharedAppState.ClearOverlay(AppState.SessionId);
+            SharedAppState.ClearOverlay(EffectiveSessionId);
         }
         else
         {
@@ -1406,9 +1457,9 @@
             string? imageUrl = null;
             if (overlay.HasImage)
             {
-                imageUrl = ImageUrlHelper.LiveOverlayImageUrl(AppState.SessionId, overlay.Id);
+                imageUrl = ImageUrlHelper.LiveOverlayImageUrl(EffectiveSessionId, overlay.Id);
             }
-            SharedAppState.SetOverlay(AppState.SessionId, overlay.Content, imageUrl);
+            SharedAppState.SetOverlay(EffectiveSessionId, overlay.Content, imageUrl);
         }
     }
 
@@ -1421,7 +1472,7 @@
         if (activeOverlayId is not null && overlaySlides.All(o => o.Id != activeOverlayId))
         {
             activeOverlayId = null;
-            SharedAppState.ClearOverlay(AppState.SessionId);
+            SharedAppState.ClearOverlay(EffectiveSessionId);
         }
     }
 

--- a/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.resx
+++ b/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.resx
@@ -1097,6 +1097,15 @@
   <data name="Templates.EditingBanner" xml:space="preserve">
     <value>You are editing a template</value>
   </data>
+  <data name="RemoteControl.Banner" xml:space="preserve">
+    <value>Remote control mode – you are controlling a live presentation</value>
+  </data>
+  <data name="RemoteControl.NoActivePresentation" xml:space="preserve">
+    <value>No active presentation right now</value>
+  </data>
+  <data name="RemoteControl.NotEnabled" xml:space="preserve">
+    <value>Remote control has not been enabled by the presenter</value>
+  </data>
   <data name="Templates.DeleteConfirm" xml:space="preserve">
     <value>Are you sure you want to delete this template?</value>
   </data>
@@ -1120,6 +1129,18 @@
   </data>
   <data name="Dashboard.Live" xml:space="preserve">
     <value>Live</value>
+  </data>
+  <data name="Dashboard.LiveNow" xml:space="preserve">
+    <value>Showing now</value>
+  </data>
+  <data name="Dashboard.LiveNowUnknown" xml:space="preserve">
+    <value>Active presentation</value>
+  </data>
+  <data name="Dashboard.TakeControl" xml:space="preserve">
+    <value>Take control</value>
+  </data>
+  <data name="LivePanel.RemoteControl" xml:space="preserve">
+    <value>Allow remote control</value>
   </data>
   <data name="Dashboard.Today" xml:space="preserve">
     <value>Today</value>

--- a/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.sv.resx
+++ b/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.sv.resx
@@ -1097,6 +1097,15 @@
   <data name="Templates.EditingBanner" xml:space="preserve">
     <value>Du redigerar en mall</value>
   </data>
+  <data name="RemoteControl.Banner" xml:space="preserve">
+    <value>Fjärrstyrningsläge – du styr en aktiv presentation</value>
+  </data>
+  <data name="RemoteControl.NoActivePresentation" xml:space="preserve">
+    <value>Ingen aktiv presentation just nu</value>
+  </data>
+  <data name="RemoteControl.NotEnabled" xml:space="preserve">
+    <value>Fjärrstyrning är inte aktiverad av presentatören</value>
+  </data>
   <data name="Templates.DeleteConfirm" xml:space="preserve">
     <value>Är du säker på att du vill ta bort mallen?</value>
   </data>
@@ -1120,6 +1129,18 @@
   </data>
   <data name="Dashboard.Live" xml:space="preserve">
     <value>Live</value>
+  </data>
+  <data name="Dashboard.LiveNow" xml:space="preserve">
+    <value>Visas just nu</value>
+  </data>
+  <data name="Dashboard.LiveNowUnknown" xml:space="preserve">
+    <value>Aktiv presentation</value>
+  </data>
+  <data name="Dashboard.TakeControl" xml:space="preserve">
+    <value>Ta kontroll</value>
+  </data>
+  <data name="LivePanel.RemoteControl" xml:space="preserve">
+    <value>Tillåt fjärrstyrning</value>
   </data>
   <data name="Dashboard.Today" xml:space="preserve">
     <value>Idag</value>

--- a/GospelPresenter/GospelPresenter.Shared/State/SharedAppState.cs
+++ b/GospelPresenter/GospelPresenter.Shared/State/SharedAppState.cs
@@ -24,6 +24,7 @@ public partial class SharedAppState : ObservableObject
     private readonly ConcurrentDictionary<string, DateTime> lastAccessed = new();
     private readonly ConcurrentDictionary<string, DateTime> expiredSessions = new();
     private readonly ConcurrentDictionary<string, CancellationTokenSource> ccliTimers = new();
+    private readonly ConcurrentDictionary<string, bool> remoteControlEnabled = new();
 
     public static readonly LiveSlide DefaultSlide = new(
         LiveSlideStatus.ShowingPresentation,
@@ -99,9 +100,28 @@ public partial class SharedAppState : ObservableObject
     {
         TouchSession(sessionId);
         presentationActive.TryRemove(sessionId, out _);
+        remoteControlEnabled.TryRemove(sessionId, out _);
         OnPropertyChanged(sessionId);
         PresentationDeactivated?.Invoke(sessionId);
     }
+
+    public void EnableRemoteControl(string sessionId)
+    {
+        remoteControlEnabled[sessionId] = true;
+        OnPropertyChanged(sessionId);
+    }
+
+    public void DisableRemoteControl(string sessionId)
+    {
+        remoteControlEnabled.TryRemove(sessionId, out _);
+        OnPropertyChanged(sessionId);
+    }
+
+    public bool IsRemoteControlEnabled(string sessionId) =>
+        remoteControlEnabled.GetValueOrDefault(sessionId, false);
+
+    public ActiveSession? GetActiveSession(string sessionId) =>
+        presentationActive.GetValueOrDefault(sessionId);
 
     public event Action<string>? PresentationActivated;
     public event Action<string>? PresentationDeactivated;
@@ -225,6 +245,7 @@ public partial class SharedAppState : ObservableObject
             liveSlides.TryRemove(sessionId, out _);
             activeOverlays.TryRemove(sessionId, out _);
             presentationActive.TryRemove(sessionId, out _);
+            remoteControlEnabled.TryRemove(sessionId, out _);
             lastAccessed.TryRemove(sessionId, out _);
 
             if (wasActive)


### PR DESCRIPTION
Allows a presenter to enable remote control of a live presentation, so
any org member can navigate slides, toggle overlays, and stop the
presentation from another browser session.

- SharedAppState: adds EnableRemoteControl/DisableRemoteControl/IsRemoteControlEnabled
  per session, plus GetActiveSession for dashboard use
- LivePanel: adds toggle button 'Tillåt fjärrstyrning' that enables/disables
  remote control for the active session
- Presentation.razor: adds ?remote=true query param that switches page into
  remote control mode, using EffectiveSessionId (presenter's session) for all
  live state mutations; shows amber banner and guards live panel with IsRemoteReady
- Dashboard: shows 'Visas just nu' card with 'Ta kontroll' link when a
  presentation with remote control enabled is active in the org
- Localization: adds RemoteControl.* and Dashboard.LiveNow/TakeControl/LivePanel.RemoteControl
  keys to both en and sv resource files

https://claude.ai/code/session_01UwzsNyMYdPKQJTo8qGTVtB