### PR TITLE
Audio improvements: iOS fix, remote audio on presenter device, persistent player

### DIFF
--- a/GospelPresenter/GospelPresenter.Shared/Components/Dashboard.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Dashboard.razor
@@ -180,6 +180,7 @@
             if (orgId is null) return null;
             var sessionId = SharedAppState.GetActiveSessionIdForOrganization(orgId);
             if (sessionId is null || !SharedAppState.IsRemoteControlEnabled(sessionId)) return null;
+            if (sessionId == AppState.SessionId) return null;
             return sessionId;
         }
     }

--- a/GospelPresenter/GospelPresenter.Shared/Components/Presentations/LivePanel.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Presentations/LivePanel.razor
@@ -196,7 +196,7 @@
 
 @{
     var remoteAudioItem = SessionId is not null && !IsRemoteController
-        ? SharedAppState.GetRemoteAudio(SessionId)
+        ? SharedAppState.GetSessionAudio(SessionId)
         : null;
 }
 @if (remoteAudioItem is not null)

--- a/GospelPresenter/GospelPresenter.Shared/Components/Presentations/LivePanel.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Presentations/LivePanel.razor
@@ -194,6 +194,25 @@
     }
 }
 
+@{
+    var remoteAudioItem = SessionId is not null && !IsRemoteController
+        ? SharedAppState.GetRemoteAudio(SessionId)
+        : null;
+}
+@if (remoteAudioItem is not null)
+{
+    <div class="text-[10px] uppercase tracking-widest text-neutral-400 dark:text-neutral-500 font-semibold mt-4 mb-2">
+        @L["LivePanel.RemoteAudio"]
+    </div>
+    <div id="live-panel-audio-container">
+        @for (var i = 0; i < remoteAudioItem.Parts.Count; i++)
+        {
+            var part = remoteAudioItem.Parts[i];
+            <AudioPlayer AudioElementId="@($"live-panel-audio-{i}")" FileName="@part.FileName" Url="@part.Url" ContainerId="live-panel-audio-container"/>
+        }
+    </div>
+}
+
 @if (ShowGrow)
 {
     <div class="grow"></div>

--- a/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
@@ -1241,6 +1241,9 @@
         isEditingItemTitle = false;
         imageSortableInitialized = false;
 
+        if (IsRemoteMode && _presenterSessionId is not null)
+            SharedAppState.SetRemoteAudio(_presenterSessionId, null);
+
         switch (AppState.SelectedProjectItem?.Type)
         {
             case ProjectItemType.Song:
@@ -1308,7 +1311,11 @@
                             return new AudioPart(p.Id, audioId, fileName, ImageUrlHelper.OrgAudioUrl(audioId));
                         })
                         .ToList();
-                    SelectedAudio = new Audio(audioItem.Id, audioParts);
+                    var audio = new Audio(audioItem.Id, audioParts);
+                    if (IsRemoteMode && _presenterSessionId is not null)
+                        SharedAppState.SetRemoteAudio(_presenterSessionId, audio);
+                    else
+                        SelectedAudio = audio;
                 }
                 break;
             case ProjectItemType.Slides:

--- a/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
@@ -1241,9 +1241,6 @@
         isEditingItemTitle = false;
         imageSortableInitialized = false;
 
-        if (IsRemoteMode && _presenterSessionId is not null)
-            SharedAppState.SetRemoteAudio(_presenterSessionId, null);
-
         switch (AppState.SelectedProjectItem?.Type)
         {
             case ProjectItemType.Song:
@@ -1313,7 +1310,9 @@
                         .ToList();
                     var audio = new Audio(audioItem.Id, audioParts);
                     if (IsRemoteMode && _presenterSessionId is not null)
-                        SharedAppState.SetRemoteAudio(_presenterSessionId, audio);
+                        SharedAppState.SetSessionAudio(_presenterSessionId, audio);
+                    else if (SharedAppState.IsPresentationActive(AppState.SessionId))
+                        SharedAppState.SetSessionAudio(AppState.SessionId, audio);
                     else
                         SelectedAudio = audio;
                 }

--- a/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.resx
+++ b/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.resx
@@ -1142,6 +1142,9 @@
   <data name="LivePanel.RemoteControl" xml:space="preserve">
     <value>Allow remote control</value>
   </data>
+  <data name="LivePanel.RemoteAudio" xml:space="preserve">
+    <value>Audio</value>
+  </data>
   <data name="Dashboard.Today" xml:space="preserve">
     <value>Today</value>
   </data>

--- a/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.sv.resx
+++ b/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.sv.resx
@@ -1142,6 +1142,9 @@
   <data name="LivePanel.RemoteControl" xml:space="preserve">
     <value>Tillåt fjärrstyrning</value>
   </data>
+  <data name="LivePanel.RemoteAudio" xml:space="preserve">
+    <value>Ljud</value>
+  </data>
   <data name="Dashboard.Today" xml:space="preserve">
     <value>Idag</value>
   </data>

--- a/GospelPresenter/GospelPresenter.Shared/State/SharedAppState.cs
+++ b/GospelPresenter/GospelPresenter.Shared/State/SharedAppState.cs
@@ -25,7 +25,7 @@ public partial class SharedAppState : ObservableObject
     private readonly ConcurrentDictionary<string, DateTime> expiredSessions = new();
     private readonly ConcurrentDictionary<string, CancellationTokenSource> ccliTimers = new();
     private readonly ConcurrentDictionary<string, bool> remoteControlEnabled = new();
-    private readonly ConcurrentDictionary<string, Audio> remoteAudio = new();
+    private readonly ConcurrentDictionary<string, Audio> sessionAudio = new();
 
     public static readonly LiveSlide DefaultSlide = new(
         LiveSlideStatus.ShowingPresentation,
@@ -102,7 +102,7 @@ public partial class SharedAppState : ObservableObject
         TouchSession(sessionId);
         presentationActive.TryRemove(sessionId, out _);
         remoteControlEnabled.TryRemove(sessionId, out _);
-        remoteAudio.TryRemove(sessionId, out _);
+        sessionAudio.TryRemove(sessionId, out _);
         OnPropertyChanged(sessionId);
         PresentationDeactivated?.Invoke(sessionId);
     }
@@ -122,17 +122,17 @@ public partial class SharedAppState : ObservableObject
     public bool IsRemoteControlEnabled(string sessionId) =>
         remoteControlEnabled.GetValueOrDefault(sessionId, false);
 
-    public void SetRemoteAudio(string sessionId, Audio? audio)
+    public void SetSessionAudio(string sessionId, Audio? audio)
     {
         if (audio is null)
-            remoteAudio.TryRemove(sessionId, out _);
+            sessionAudio.TryRemove(sessionId, out _);
         else
-            remoteAudio[sessionId] = audio;
+            sessionAudio[sessionId] = audio;
         OnPropertyChanged(sessionId);
     }
 
-    public Audio? GetRemoteAudio(string sessionId) =>
-        remoteAudio.GetValueOrDefault(sessionId);
+    public Audio? GetSessionAudio(string sessionId) =>
+        sessionAudio.GetValueOrDefault(sessionId);
 
     public ActiveSession? GetActiveSession(string sessionId) =>
         presentationActive.GetValueOrDefault(sessionId);
@@ -260,7 +260,7 @@ public partial class SharedAppState : ObservableObject
             activeOverlays.TryRemove(sessionId, out _);
             presentationActive.TryRemove(sessionId, out _);
             remoteControlEnabled.TryRemove(sessionId, out _);
-            remoteAudio.TryRemove(sessionId, out _);
+            sessionAudio.TryRemove(sessionId, out _);
             lastAccessed.TryRemove(sessionId, out _);
 
             if (wasActive)

--- a/GospelPresenter/GospelPresenter.Shared/State/SharedAppState.cs
+++ b/GospelPresenter/GospelPresenter.Shared/State/SharedAppState.cs
@@ -25,6 +25,7 @@ public partial class SharedAppState : ObservableObject
     private readonly ConcurrentDictionary<string, DateTime> expiredSessions = new();
     private readonly ConcurrentDictionary<string, CancellationTokenSource> ccliTimers = new();
     private readonly ConcurrentDictionary<string, bool> remoteControlEnabled = new();
+    private readonly ConcurrentDictionary<string, Audio> remoteAudio = new();
 
     public static readonly LiveSlide DefaultSlide = new(
         LiveSlideStatus.ShowingPresentation,
@@ -101,6 +102,7 @@ public partial class SharedAppState : ObservableObject
         TouchSession(sessionId);
         presentationActive.TryRemove(sessionId, out _);
         remoteControlEnabled.TryRemove(sessionId, out _);
+        remoteAudio.TryRemove(sessionId, out _);
         OnPropertyChanged(sessionId);
         PresentationDeactivated?.Invoke(sessionId);
     }
@@ -119,6 +121,18 @@ public partial class SharedAppState : ObservableObject
 
     public bool IsRemoteControlEnabled(string sessionId) =>
         remoteControlEnabled.GetValueOrDefault(sessionId, false);
+
+    public void SetRemoteAudio(string sessionId, Audio? audio)
+    {
+        if (audio is null)
+            remoteAudio.TryRemove(sessionId, out _);
+        else
+            remoteAudio[sessionId] = audio;
+        OnPropertyChanged(sessionId);
+    }
+
+    public Audio? GetRemoteAudio(string sessionId) =>
+        remoteAudio.GetValueOrDefault(sessionId);
 
     public ActiveSession? GetActiveSession(string sessionId) =>
         presentationActive.GetValueOrDefault(sessionId);
@@ -246,6 +260,7 @@ public partial class SharedAppState : ObservableObject
             activeOverlays.TryRemove(sessionId, out _);
             presentationActive.TryRemove(sessionId, out _);
             remoteControlEnabled.TryRemove(sessionId, out _);
+            remoteAudio.TryRemove(sessionId, out _);
             lastAccessed.TryRemove(sessionId, out _);
 
             if (wasActive)

--- a/GospelPresenter/GospelPresenter.Web/Program.cs
+++ b/GospelPresenter/GospelPresenter.Web/Program.cs
@@ -614,8 +614,14 @@ builder.Services.AddMetricServer(options =>
         if (result is null) return Results.NotFound();
 
         var (stream, contentType) = result.Value;
+        // Buffer into MemoryStream so the response supports range requests.
+        // iOS Safari requires range request support (206 Partial Content) to play audio.
+        // The S3 response stream is not seekable, so we buffer it first.
+        var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+        ms.Seek(0, SeekOrigin.Begin);
         context.Response.Headers.CacheControl = "public, max-age=31536000, immutable";
-        return Results.File(stream, contentType);
+        return Results.File(ms, contentType, enableRangeProcessing: true);
     }).RequireAuthorization();
 
     // MCP API key authentication middleware


### PR DESCRIPTION
## Summary

- **iOS audio fix**: Buffer S3 stream into `MemoryStream` and enable `enableRangeProcessing: true` on the audio endpoint. iOS Safari requires HTTP 206 range responses to play audio — the raw S3 stream is non-seekable so ASP.NET Core couldn't serve range requests without buffering.
- **Remote audio on presenter's device**: When remote-controlling a presentation, selecting an audio item pushes the audio to the presenter's session via `SharedAppState.SetSessionAudio`. The audio player appears in the presenter's `LivePanel` so playback happens on the presenting device, not the controller's device.
- **Persistent audio player during live presentation**: Moved audio state from per-item `SelectedAudio` (destroyed on every item switch) into `SharedAppState` keyed by session ID. The `AudioPlayer` now lives in `LivePanel`, which is never torn down when navigating between slides/songs/etc., so audio continues playing uninterrupted across item switches.

## Test plan

- [ ] Play audio on iPad — should now work (previously silent)
- [ ] Start a live presentation, select an audio item, press play — audio plays in LivePanel
- [ ] While audio is playing, switch to a song or bible text — audio continues uninterrupted
- [ ] Enable remote control, open `?remote=true` on another device, select an audio item — audio player appears in the presenter's LivePanel (not the remote controller's)
- [ ] Stop presentation — audio player disappears from LivePanel

https://claude.ai/code/session_01UwzsNyMYdPKQJTo8qGTVtB