### PR TITLE
Remote presentation control + persistent audio player

### DIFF
--- a/GospelPresenter/GospelPresenter.Shared/Components/Presentations/AudioPlayer.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Presentations/AudioPlayer.razor
@@ -1,4 +1,5 @@
 @using GospelPresenter.Shared.Components.Symbols
+@inject IJSRuntime JsRuntime
 
 <div class="w-full bg-white dark:bg-neutral-800 rounded-xl p-4 shadow-sm">
     <div class="flex items-center justify-between mb-3">
@@ -43,20 +44,18 @@
         </div>
     </div>
 
-    <audio id="@audioElementId" preload="metadata" src="@Url"
-           onplay="this.volume = 1; gospelPresenter.onAudioPlay('@audioElementId', '@ContainerId')"
-           onpause="gospelPresenter.onAudioPause('@audioElementId')"
-           ontimeupdate="gospelPresenter.onAudioTimeUpdate('@audioElementId')"
-           onloadedmetadata="gospelPresenter.onAudioMetadata('@audioElementId')"
-           class="hidden"/>
 </div>
 
 @code {
     [Parameter, EditorRequired] public string AudioElementId { get; set; } = "";
     [Parameter, EditorRequired] public string FileName { get; set; } = "";
-    [Parameter, EditorRequired] public string Url { get; set; } = "";
-    [Parameter] public string ContainerId { get; set; } = "audio-container";
 
     private string audioElementId => AudioElementId;
     private string fadeButtonId => $"fade-btn-{AudioElementId}";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+            await JsRuntime.InvokeVoidAsync("gospelPresenter.syncAudioUi", audioElementId);
+    }
 }

--- a/GospelPresenter/GospelPresenter.Shared/Components/Presentations/AudioPlayerEngine.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Presentations/AudioPlayerEngine.razor
@@ -1,0 +1,12 @@
+<audio id="@AudioElementId" preload="metadata" src="@Url"
+       onplay="this.volume = 1; gospelPresenter.onAudioPlay('@AudioElementId', '@ContainerId')"
+       onpause="gospelPresenter.onAudioPause('@AudioElementId')"
+       ontimeupdate="gospelPresenter.onAudioTimeUpdate('@AudioElementId')"
+       onloadedmetadata="gospelPresenter.onAudioMetadata('@AudioElementId')"
+       class="hidden"/>
+
+@code {
+    [Parameter, EditorRequired] public string AudioElementId { get; set; } = "";
+    [Parameter, EditorRequired] public string Url { get; set; } = "";
+    [Parameter] public string ContainerId { get; set; } = "audio-container";
+}

--- a/GospelPresenter/GospelPresenter.Shared/Components/Presentations/LivePanel.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Presentations/LivePanel.razor
@@ -194,23 +194,19 @@
     }
 }
 
-@{
-    var remoteAudioItem = SessionId is not null && !IsRemoteController
-        ? SharedAppState.GetSessionAudio(SessionId)
-        : null;
-}
-@if (remoteAudioItem is not null)
+@if (SessionId is not null && !IsRemoteController)
 {
-    <div class="text-[10px] uppercase tracking-widest text-neutral-400 dark:text-neutral-500 font-semibold mt-4 mb-2">
-        @L["LivePanel.RemoteAudio"]
-    </div>
-    <div id="live-panel-audio-container">
-        @for (var i = 0; i < remoteAudioItem.Parts.Count; i++)
-        {
-            var part = remoteAudioItem.Parts[i];
-            <AudioPlayer AudioElementId="@($"live-panel-audio-{i}")" FileName="@part.FileName" Url="@part.Url" ContainerId="live-panel-audio-container"/>
-        }
-    </div>
+    var sessionAudioItem = SharedAppState.GetSessionAudio(SessionId);
+    @if (sessionAudioItem is not null)
+    {
+        <div id="live-panel-audio-container">
+            @foreach (var part in sessionAudioItem.Parts)
+            {
+                <AudioPlayerEngine AudioElementId="@($"session-audio-{part.PartId}")" Url="@part.Url" ContainerId="live-panel-audio-container"/>
+            }
+        </div>
+    }
+
 }
 
 @if (ShowGrow)

--- a/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
@@ -189,10 +189,14 @@
                 else if (SelectedAudio is not null)
                 {
                     <div id="audio-container" class="flex flex-col gap-3 w-full sm:max-w-lg sm:mx-auto px-3 pt-16 overflow-auto">
-                        @for (var i = 0; i < SelectedAudio.Parts.Count; i++)
+                        @foreach (var part in SelectedAudio.Parts)
                         {
-                            var part = SelectedAudio.Parts[i];
-                            <AudioPlayer AudioElementId="@($"audio-player-{i}")" FileName="@part.FileName" Url="@part.Url"/>
+                            var elementId = $"session-audio-{part.PartId}";
+                            @if (!SharedAppState.IsPresentationActive(AppState.SessionId))
+                            {
+                                <AudioPlayerEngine AudioElementId="@elementId" Url="@part.Url" ContainerId="audio-container"/>
+                            }
+                            <AudioPlayer AudioElementId="@elementId" FileName="@part.FileName"/>
                         }
                     </div>
                 }
@@ -1311,10 +1315,12 @@
                     var audio = new Audio(audioItem.Id, audioParts);
                     if (IsRemoteMode && _presenterSessionId is not null)
                         SharedAppState.SetSessionAudio(_presenterSessionId, audio);
-                    else if (SharedAppState.IsPresentationActive(AppState.SessionId))
-                        SharedAppState.SetSessionAudio(AppState.SessionId, audio);
                     else
+                    {
                         SelectedAudio = audio;
+                        if (SharedAppState.IsPresentationActive(AppState.SessionId))
+                            SharedAppState.SetSessionAudio(AppState.SessionId, audio);
+                    }
                 }
                 break;
             case ProjectItemType.Slides:

--- a/GospelPresenter/GospelPresenter.Shared/wwwroot/utils.js
+++ b/GospelPresenter/GospelPresenter.Shared/wwwroot/utils.js
@@ -784,6 +784,25 @@ window.gospelPresenter.onAudioTimeUpdate = function(audioId) {
     gospelPresenter.updateAudioUI(audioId, audio.currentTime, audio.duration);
 };
 
+window.gospelPresenter.syncAudioUi = function(audioId) {
+    var audio = document.getElementById(audioId);
+    if (!audio) return;
+    var playIcon = document.getElementById(audioId + '-play-icon');
+    var pauseIcon = document.getElementById(audioId + '-pause-icon');
+    if (!audio.paused) {
+        if (playIcon) playIcon.classList.add('hidden');
+        if (pauseIcon) pauseIcon.classList.remove('hidden');
+    } else {
+        if (playIcon) playIcon.classList.remove('hidden');
+        if (pauseIcon) pauseIcon.classList.add('hidden');
+    }
+    if (audio.duration) {
+        gospelPresenter.updateAudioUI(audioId, audio.currentTime, audio.duration);
+        var duration = document.getElementById(audioId + '-duration');
+        if (duration) duration.textContent = gospelPresenter.formatTime(audio.duration);
+    }
+};
+
 window.gospelPresenter.onAudioMetadata = function(audioId) {
     var audio = document.getElementById(audioId);
     if (!audio) return;


### PR DESCRIPTION
## Summary

- **Remote presentation control**: Presenters can enable remote control from LivePanel. Team members on the same org see a "Visas just nu" card on the dashboard and can take control via `/presentations/{id}?remote=true`, which opens the presentation with an amber banner indicating remote mode. All slide navigation, black screen toggle, and overlays target the presenter's session.
- **Persistent audio across item switches**: Split `AudioPlayer` (UI controls) from `AudioPlayerEngine` (the `<audio>` element). During live mode the engine lives in LivePanel so audio keeps playing when the user navigates to a different item. Controls re-mount and sync play state, progress, and time via a new `syncAudioUi` JS helper.
- **Remote audio on presenter's device**: When a remote controller selects an audio item, `SetSessionAudio` is called on the presenter's session so the engine renders in the presenter's LivePanel.
- **iOS Safari range-request fix**: Added `EnableRangeProcessing = true` to the audio file endpoint so iOS can seek and stream audio correctly.
- **Hide own session from dashboard**: A presenter won't see their own live session in the remote control card (no point in remote-controlling yourself).

## Test plan

- [ ] Start a presentation → click "Tillåt fjärrstyrning" in LivePanel
- [ ] Log in as another org member → confirm "Visas just nu" card appears on dashboard
- [ ] Click "Ta kontroll" → `/presentations/{id}?remote=true` opens with amber banner
- [ ] Navigate slides in remote mode → verify displays update on presenter's session
- [ ] Toggle black screen in remote mode → verify on displays
- [ ] Select an audio item in remote mode → verify audio plays on presenter's device, controls visible to remote controller
- [ ] Switch to a different item during live audio → verify audio keeps playing
- [ ] Presenter disables remote control → refresh remote view → error message shown
- [ ] Presenter stops presentation → "Visas just nu" disappears from dashboard
- [ ] Own session not shown in dashboard remote card
- [ ] Test audio playback on iOS Safari (seek + stream)
