### PR TITLE
Fix: audio playback fails when going live while on an audio item

### DIFF
--- a/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
@@ -48,6 +48,19 @@
             @L["RemoteControl.Banner"]
         </div>
     }
+    @if (!IsRemoteMode && !SharedAppState.IsPresentationActive(AppState.SessionId))
+    {
+        var nonLiveAudio = SharedAppState.GetSessionAudio(AppState.SessionId);
+        @if (nonLiveAudio is not null)
+        {
+            <div id="persistent-audio-container" class="hidden">
+                @foreach (var part in nonLiveAudio.Parts)
+                {
+                    <AudioPlayerEngine AudioElementId="@($"session-audio-{part.PartId}")" Url="@part.Url" ContainerId="persistent-audio-container"/>
+                }
+            </div>
+        }
+    }
     <div class="flex flex-1 min-h-0 relative">
     @{
         var menuBackdropVisibilityClass = AppState.IsMenuVisible ? "visible opacity-100" : "invisible opacity-0";
@@ -192,10 +205,6 @@
                         @foreach (var part in SelectedAudio.Parts)
                         {
                             var elementId = $"session-audio-{part.PartId}";
-                            @if (!SharedAppState.IsPresentationActive(AppState.SessionId))
-                            {
-                                <AudioPlayerEngine AudioElementId="@elementId" Url="@part.Url" ContainerId="audio-container"/>
-                            }
                             <AudioPlayer AudioElementId="@elementId" FileName="@part.FileName"/>
                         }
                     </div>
@@ -1148,6 +1157,8 @@
 
     public void Dispose()
     {
+        if (!IsRemoteMode && !SharedAppState.IsPresentationActive(AppState.SessionId))
+            SharedAppState.SetSessionAudio(AppState.SessionId, null);
         AppState.PropertyChanged -= OnPropertyChanged;
         SharedAppState.PropertyChanged -= OnPropertyChanged;
         SharedAppState.PresentationChanged -= OnPresentationChanged;
@@ -1318,8 +1329,7 @@
                     else
                     {
                         SelectedAudio = audio;
-                        if (SharedAppState.IsPresentationActive(AppState.SessionId))
-                            SharedAppState.SetSessionAudio(AppState.SessionId, audio);
+                        SharedAppState.SetSessionAudio(AppState.SessionId, audio);
                     }
                 }
                 break;


### PR DESCRIPTION
## Problem

When a user was already on an audio item and then started the presentation (went live), pressing play did nothing. The audio would only work after switching to another item and back.

**Root cause:** `SetSessionAudio` was only called if `IsPresentationActive` was already true when the item was selected. Going live while already on an audio item never triggered `SetSessionAudio`, so LivePanel had no engine to render.

## Solution

- **Engine moved to persistent page-level block** — the `<audio>` element now lives outside the item content area, rendered based on `GetSessionAudio` rather than `SelectedAudio`. It survives item switches.
- **`SetSessionAudio` always called** when selecting an audio item, regardless of live state — so LivePanel always has the data it needs when presentation starts.
- **Bonus:** audio keeps playing when navigating to other items in non-live mode (engine persists outside content area).

## Test plan

- [ ] Open a presentation, select an audio item, start the presentation → press play → audio should work immediately
- [ ] While live on audio, navigate to a song item and back → audio should still be playing
- [ ] While non-live, select audio and play → navigate to another item → audio keeps playing
- [ ] Stop/restart presentation → audio state is clean
