### PR TITLE
Fix: audio controls saknas för remote-user + play fungerar inte efter stop

### DIFF
--- a/GospelPresenter/GospelPresenter.Shared/Components/Presentations/AudioPlayerEngine.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Presentations/AudioPlayerEngine.razor
@@ -1,4 +1,5 @@
 <audio id="@AudioElementId" preload="metadata" src="@Url"
+       muted="@(Muted ? "" : null)"
        onplay="this.volume = 1; gospelPresenter.onAudioPlay('@AudioElementId', '@ContainerId')"
        onpause="gospelPresenter.onAudioPause('@AudioElementId')"
        ontimeupdate="gospelPresenter.onAudioTimeUpdate('@AudioElementId')"
@@ -9,4 +10,5 @@
     [Parameter, EditorRequired] public string AudioElementId { get; set; } = "";
     [Parameter, EditorRequired] public string Url { get; set; } = "";
     [Parameter] public string ContainerId { get; set; } = "audio-container";
+    [Parameter] public bool Muted { get; set; }
 }

--- a/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
@@ -48,7 +48,7 @@
             @L["RemoteControl.Banner"]
         </div>
     }
-    @if (!IsRemoteMode && !SharedAppState.IsPresentationActive(AppState.SessionId))
+    @if (!SharedAppState.IsPresentationActive(AppState.SessionId))
     {
         var nonLiveAudio = SharedAppState.GetSessionAudio(AppState.SessionId);
         @if (nonLiveAudio is not null)
@@ -760,6 +760,8 @@
         await JsRuntime.InvokeVoidAsync("stopLivePresentation", EffectiveSessionId);
         ResetLiveSlide();
         SharedAppState.DeactivatePresentation(EffectiveSessionId);
+        if (SelectedAudio is not null)
+            SharedAppState.SetSessionAudio(AppState.SessionId, SelectedAudio);
     }
 
     private void ResetLiveSlide()
@@ -1157,7 +1159,7 @@
 
     public void Dispose()
     {
-        if (!IsRemoteMode && !SharedAppState.IsPresentationActive(AppState.SessionId))
+        if (!SharedAppState.IsPresentationActive(AppState.SessionId))
             SharedAppState.SetSessionAudio(AppState.SessionId, null);
         AppState.PropertyChanged -= OnPropertyChanged;
         SharedAppState.PropertyChanged -= OnPropertyChanged;
@@ -1324,13 +1326,10 @@
                         })
                         .ToList();
                     var audio = new Audio(audioItem.Id, audioParts);
+                    SelectedAudio = audio;
                     if (IsRemoteMode && _presenterSessionId is not null)
                         SharedAppState.SetSessionAudio(_presenterSessionId, audio);
-                    else
-                    {
-                        SelectedAudio = audio;
-                        SharedAppState.SetSessionAudio(AppState.SessionId, audio);
-                    }
+                    SharedAppState.SetSessionAudio(AppState.SessionId, audio);
                 }
                 break;
             case ProjectItemType.Slides:

--- a/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
@@ -56,7 +56,7 @@
             <div id="persistent-audio-container" class="hidden">
                 @foreach (var part in nonLiveAudio.Parts)
                 {
-                    <AudioPlayerEngine AudioElementId="@($"session-audio-{part.PartId}")" Url="@part.Url" ContainerId="persistent-audio-container"/>
+                    <AudioPlayerEngine AudioElementId="@($"session-audio-{part.PartId}")" Url="@part.Url" ContainerId="persistent-audio-container" Muted="@IsRemoteMode"/>
                 }
             </div>
         }

--- a/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Pages/Presentation.razor
@@ -732,6 +732,8 @@
         if (firstRender)
         {
             dotNetRef = DotNetObjectReference.Create(this);
+            if (IsRemoteMode)
+                await JsRuntime.InvokeVoidAsync("gospelPresenter.registerAudioRelay", dotNetRef);
         }
 
         if (isEditingItemTitle)
@@ -1157,10 +1159,19 @@
         ToastService.Show(L["Toast.SavedAsTemplate"]);
     }
 
+    [JSInvokable]
+    public void OnRemoteAudioCommand(string action, string audioElementId, double? position)
+    {
+        if (!IsRemoteMode || _presenterSessionId is null) return;
+        SharedAppState.SetAudioCommand(_presenterSessionId, new AudioCommand(action, audioElementId, position));
+    }
+
     public void Dispose()
     {
         if (!SharedAppState.IsPresentationActive(AppState.SessionId))
             SharedAppState.SetSessionAudio(AppState.SessionId, null);
+        if (IsRemoteMode)
+            _ = JsRuntime.InvokeVoidAsync("gospelPresenter.unregisterAudioRelay").AsTask();
         AppState.PropertyChanged -= OnPropertyChanged;
         SharedAppState.PropertyChanged -= OnPropertyChanged;
         SharedAppState.PresentationChanged -= OnPresentationChanged;
@@ -1237,6 +1248,11 @@
                 showSessionExpired = true;
                 SharedAppState.ClearSessionExpired(AppState.SessionId);
             }
+
+            var cmd = SharedAppState.TakeAudioCommand(AppState.SessionId);
+            if (cmd is not null && !IsRemoteMode)
+                _ = InvokeAsync(() => JsRuntime.InvokeVoidAsync(
+                    "gospelPresenter.executeAudioCommand", cmd.Action, cmd.AudioElementId, cmd.Position).AsTask());
 
             _ = InvokeAsync(StateHasChanged);
         }

--- a/GospelPresenter/GospelPresenter.Shared/State/SharedAppState.cs
+++ b/GospelPresenter/GospelPresenter.Shared/State/SharedAppState.cs
@@ -9,6 +9,8 @@ public record CcliSongDisplayedEvent(
     string OrganizationId, string SongId, string SongName, string CcliNumber,
     string? PresentationId, string? PresentationName);
 
+public record AudioCommand(string Action, string AudioElementId, double? Position);
+
 public partial class SharedAppState : ObservableObject
 {
     private readonly TimeSpan sessionTimeout;
@@ -26,6 +28,7 @@ public partial class SharedAppState : ObservableObject
     private readonly ConcurrentDictionary<string, CancellationTokenSource> ccliTimers = new();
     private readonly ConcurrentDictionary<string, bool> remoteControlEnabled = new();
     private readonly ConcurrentDictionary<string, Audio> sessionAudio = new();
+    private readonly ConcurrentDictionary<string, AudioCommand> pendingAudioCommands = new();
 
     public static readonly LiveSlide DefaultSlide = new(
         LiveSlideStatus.ShowingPresentation,
@@ -103,6 +106,7 @@ public partial class SharedAppState : ObservableObject
         presentationActive.TryRemove(sessionId, out _);
         remoteControlEnabled.TryRemove(sessionId, out _);
         sessionAudio.TryRemove(sessionId, out _);
+        pendingAudioCommands.TryRemove(sessionId, out _);
         OnPropertyChanged(sessionId);
         PresentationDeactivated?.Invoke(sessionId);
     }
@@ -133,6 +137,18 @@ public partial class SharedAppState : ObservableObject
 
     public Audio? GetSessionAudio(string sessionId) =>
         sessionAudio.GetValueOrDefault(sessionId);
+
+    public void SetAudioCommand(string sessionId, AudioCommand command)
+    {
+        pendingAudioCommands[sessionId] = command;
+        OnPropertyChanged(sessionId);
+    }
+
+    public AudioCommand? TakeAudioCommand(string sessionId)
+    {
+        pendingAudioCommands.TryRemove(sessionId, out var cmd);
+        return cmd;
+    }
 
     public ActiveSession? GetActiveSession(string sessionId) =>
         presentationActive.GetValueOrDefault(sessionId);
@@ -261,6 +277,7 @@ public partial class SharedAppState : ObservableObject
             presentationActive.TryRemove(sessionId, out _);
             remoteControlEnabled.TryRemove(sessionId, out _);
             sessionAudio.TryRemove(sessionId, out _);
+            pendingAudioCommands.TryRemove(sessionId, out _);
             lastAccessed.TryRemove(sessionId, out _);
 
             if (wasActive)

--- a/GospelPresenter/GospelPresenter.Shared/wwwroot/utils.js
+++ b/GospelPresenter/GospelPresenter.Shared/wwwroot/utils.js
@@ -682,7 +682,27 @@ window.gospelPresenter.formatTime = function(seconds) {
     return mins + ':' + (secs < 10 ? '0' : '') + secs;
 };
 
+window.gospelPresenter._audioRelay = null;
+
+window.gospelPresenter.registerAudioRelay = function(dotnetRef) {
+    window.gospelPresenter._audioRelay = dotnetRef;
+};
+
+window.gospelPresenter.unregisterAudioRelay = function() {
+    window.gospelPresenter._audioRelay = null;
+};
+
+window.gospelPresenter.executeAudioCommand = function(action, audioId, position) {
+    var audio = document.getElementById(audioId);
+    if (!audio) return;
+    if (action === 'toggle') { if (audio.paused) audio.play(); else audio.pause(); }
+    else if (action === 'seek' && position != null) { audio.currentTime = position; }
+    else if (action === 'fade') { gospelPresenter.fadeOutAudio(audio, null); }
+};
+
 window.gospelPresenter.toggleAudio = function(audioId) {
+    if (window.gospelPresenter._audioRelay)
+        window.gospelPresenter._audioRelay.invokeMethodAsync('OnRemoteAudioCommand', 'toggle', audioId, null);
     var audio = document.getElementById(audioId);
     if (!audio) return;
     if (audio.paused) audio.play();
@@ -735,6 +755,8 @@ window.gospelPresenter.startSeek = function(audioId, event, bar) {
         if (debounceTimer) clearTimeout(debounceTimer);
         audio._seeking = false;
         audio.volume = originalVolume;
+        if (window.gospelPresenter._audioRelay)
+            window.gospelPresenter._audioRelay.invokeMethodAsync('OnRemoteAudioCommand', 'seek', audioId, audio.currentTime);
     }
 
     document.addEventListener('mousemove', onMove);
@@ -835,6 +857,8 @@ window.gospelPresenter.fadeOutAudio = function(audioElement, button, durationMs)
     durationMs = durationMs || 5000;
     if (audioElement.paused) return;
     if (audioElement._fadeInterval) return;
+    if (window.gospelPresenter._audioRelay)
+        window.gospelPresenter._audioRelay.invokeMethodAsync('OnRemoteAudioCommand', 'fade', audioElement.id, null);
 
     var startVolume = audioElement.volume;
     var startTime = Date.now();


### PR DESCRIPTION
## Bugfixar för audio-spelaren

### Bug 1: Inga kontroller visas för remote-användaren
`SelectedAudio` sattes aldrig i remote-läge → `AudioPlayer`-kontrollerna renderades inte alls. Nu sätts `SelectedAudio` alltid, oavsett läge. Remote-användaren får också sin egen persistent engine (lokal uppspelning/monitor), och presenterarens LivePanel behåller sin engine för PA-output.

### Bug 2: Play fungerar inte efter man stängt av live-presentation
`DeactivatePresentation` städar bort `sessionAudio` → persistent engine-blocket försvinner → play-knappen slutar fungera tills man navigerar bort och tillbaka. Nu återställs `sessionAudio` direkt i `StopPresentation()` om ett audio-item fortfarande är valt.
