### PR TITLE
perf: fix landing page rendering performance and iOS Safari carousel freeze

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -59,7 +59,7 @@
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5"/></svg>
             </button>
             <div id="carousel-viewport" class="flex-1 overflow-hidden">
-              <div id="carousel-container" class="flex touch-pan-y"></div>
+              <div id="carousel-container" class="flex"></div>
             </div>
             <button id="carousel-next" class="shrink-0 p-2 rounded-full bg-white dark:bg-neutral-800 shadow text-neutral-600 dark:text-neutral-300 hover:text-sky-500 dark:hover:text-sky-400 cursor-pointer transition-colors">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6"><path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"/></svg>

--- a/docs/src/main.js
+++ b/docs/src/main.js
@@ -14,10 +14,10 @@ if (location.pathname === "/" && !localStorage.getItem("lang")) {
 const navbar = document.getElementById("navbar");
 window.addEventListener("scroll", () => {
   const scrolled = window.scrollY > 10;
-  navbar.classList.toggle("bg-white/80", scrolled);
-  navbar.classList.toggle("dark:bg-neutral-900/80", scrolled);
-  navbar.classList.toggle("backdrop-blur-sm", scrolled);
-});
+  navbar.classList.toggle("bg-white/95", scrolled);
+  navbar.classList.toggle("dark:bg-neutral-900/95", scrolled);
+  navbar.classList.toggle("shadow-sm", scrolled);
+}, { passive: true });
 
 // Mark manual language choice when clicking a language link
 document.querySelectorAll("[data-lang]").forEach((el) => {

--- a/docs/src/style.css
+++ b/docs/src/style.css
@@ -49,39 +49,34 @@
   content: "";
   position: absolute;
   border-radius: 50%;
-  filter: blur(120px);
   pointer-events: none;
 }
 
 .animated-bg::before {
-  width: 600px;
-  height: 600px;
-  background: #0ea5e9;
-  top: -200px;
-  left: -100px;
-  opacity: 0.15;
+  width: 800px;
+  height: 800px;
+  background: radial-gradient(circle, rgba(14, 165, 233, 0.15) 0%, transparent 70%);
+  top: -300px;
+  left: -200px;
   animation: blob-1 18s ease-in-out infinite;
 }
 
 .animated-bg::after {
-  width: 500px;
-  height: 500px;
-  background: #38bdf8;
-  top: -100px;
-  right: -100px;
-  opacity: 0.12;
+  width: 680px;
+  height: 680px;
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.12) 0%, transparent 70%);
+  top: -200px;
+  right: -200px;
   animation: blob-2 22s ease-in-out infinite;
 }
 
 .blob-3 {
   position: absolute;
-  width: 450px;
-  height: 450px;
-  background: #0ea5e9;
+  width: 620px;
+  height: 620px;
+  background: radial-gradient(circle, rgba(14, 165, 233, 0.1) 0%, transparent 70%);
   border-radius: 50%;
-  filter: blur(120px);
-  opacity: 0.1;
-  top: 200px;
+  top: 100px;
   left: 50%;
   transform: translateX(-50%);
   animation: blob-3 20s ease-in-out infinite;
@@ -91,18 +86,15 @@
 
 @media (prefers-color-scheme: dark) {
   .animated-bg::before {
-    background: #0284c7;
-    opacity: 0.2;
+    background: radial-gradient(circle, rgba(2, 132, 199, 0.2) 0%, transparent 70%);
   }
 
   .animated-bg::after {
-    background: #0ea5e9;
-    opacity: 0.15;
+    background: radial-gradient(circle, rgba(14, 165, 233, 0.15) 0%, transparent 70%);
   }
 
   .blob-3 {
-    background: #0284c7;
-    opacity: 0.12;
+    background: radial-gradient(circle, rgba(2, 132, 199, 0.12) 0%, transparent 70%);
   }
 }
 

--- a/docs/src/style.css
+++ b/docs/src/style.css
@@ -50,6 +50,7 @@
   position: absolute;
   border-radius: 50%;
   pointer-events: none;
+  will-change: transform;
 }
 
 .animated-bg::before {
@@ -78,7 +79,7 @@
   border-radius: 50%;
   top: 100px;
   left: 50%;
-  transform: translateX(-50%);
+  will-change: transform;
   animation: blob-3 20s ease-in-out infinite;
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary

- Replace `filter:blur(120px)` on animated background blobs with `radial-gradient` — eliminates expensive software rasterization on every frame
- Add `will-change: transform` to blob elements so Safari pre-promotes them to GPU layers before touch events fire
- Remove `touch-pan-y` from `#carousel-container` — Embla manages `touch-action` itself on the viewport, having it on the container caused touch conflicts on iOS
- Replace `backdrop-filter: blur()` on navbar scroll with `bg-white/95 + shadow-sm` — `backdrop-filter` runs on the main thread on iOS Safari and contributed to carousel freeze

## Test plan

- [ ] Verify landing page blobs still animate visually on desktop
- [ ] Verify navbar shows solid background (no frosted glass) on scroll
- [ ] Test carousel swipe on iPhone — should no longer freeze Safari