### PR TITLE
Split FAQ language and data storage into separate questions

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -298,6 +298,13 @@
             </summary>
             <p class="pb-5 text-slate-600 dark:text-slate-400">{{faq_a17}}</p>
           </details>
+          <details class="group border-b border-slate-200 dark:border-neutral-800">
+            <summary class="flex items-center justify-between gap-4 py-5 cursor-pointer list-none [&::-webkit-details-marker]:hidden font-medium text-neutral-800 dark:text-neutral-100">
+              <span>{{faq_q18}}</span>
+              <svg class="w-5 h-5 text-sky-500 transition-transform group-open:rotate-180 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+            </summary>
+            <p class="pb-5 text-slate-600 dark:text-slate-400">{{faq_a18}}</p>
+          </details>
         </div>
       </div>
 

--- a/docs/src/i18n/en.json
+++ b/docs/src/i18n/en.json
@@ -62,12 +62,14 @@
   "faq_a12": "You can choose font family, weight, text size, and line height for song lyrics and Bible verses. Colors and customizable backgrounds are not yet implemented but are in the pipeline.",
   "faq_q13": "Can multiple people control the presentation at the same time?",
   "faq_a13": "Yes. You can control it from any device with a browser — computer, phone, or tablet. This works over a local network or over the internet, depending on how the server is exposed. You can also hand off control to another device mid-service.",
-  "faq_q14": "Which languages does the interface have, and where is our data stored?",
-  "faq_a14": "The interface is currently available in English and Swedish. All data — songs, presentations, images, and uploaded files — is stored on your own server (PostgreSQL plus an S3-compatible object store). No data is sent to us or any third party.",
-  "faq_q15": "What does \"Alpha\" mean?",
-  "faq_a15": "Gospel Presenter is under active development. That means features are added continuously, things may change, and bugs may occur. Feel free to try the tool, but expect it to still be maturing. Feedback helps us prioritize.",
-  "faq_q16": "How can I contribute or report bugs?",
-  "faq_a16": "All development happens openly on GitHub. There you can report bugs, suggest features, or contribute code. Pull requests and feedback are welcome.",
-  "faq_q17": "Are there any experimental or AI-related features?",
-  "faq_a17": "Yes. Gospel Presenter has a built-in MCP server (Model Context Protocol) that lets AI assistants like Claude work directly with your presentations — for example listing, creating, or editing them, fetching song lyrics, or searching the Bible. That means you can use AI to quickly put together a presentation based on the day's sermon or song repertoire. The feature is experimental and under development."
+  "faq_q14": "Which languages does the interface support?",
+  "faq_a14": "The interface is currently available in English and Swedish.",
+  "faq_q15": "Where is our data stored?",
+  "faq_a15": "All data — songs, presentations, images, and uploaded files — is stored on your own server (PostgreSQL plus an S3-compatible object store). No data is sent to us or any third party.",
+  "faq_q16": "What does \"Alpha\" mean?",
+  "faq_a16": "Gospel Presenter is under active development. That means features are added continuously, things may change, and bugs may occur. Feel free to try the tool, but expect it to still be maturing. Feedback helps us prioritize.",
+  "faq_q17": "How can I contribute or report bugs?",
+  "faq_a17": "All development happens openly on GitHub. There you can report bugs, suggest features, or contribute code. Pull requests and feedback are welcome.",
+  "faq_q18": "Are there any experimental or AI-related features?",
+  "faq_a18": "Yes. Gospel Presenter has a built-in MCP server (Model Context Protocol) that lets AI assistants like Claude work directly with your presentations — for example listing, creating, or editing them, fetching song lyrics, or searching the Bible. That means you can use AI to quickly put together a presentation based on the day's sermon or song repertoire. The feature is experimental and under development."
 }

--- a/docs/src/i18n/sv.json
+++ b/docs/src/i18n/sv.json
@@ -62,12 +62,14 @@
   "faq_a12": "Du kan välja typsnitt, tjocklek, textstorlek och radhöjd för sångtext och bibelverser. Färger och anpassningsbara bakgrunder är ännu inte implementerade men ligger i pipeline.",
   "faq_q13": "Kan flera personer styra presentationen samtidigt?",
   "faq_a13": "Ja. Du kan styra från valfri enhet med webbläsare – dator, mobil eller surfplatta. Det fungerar både över lokalt nätverk och över internet, beroende på hur servern är tillgänglig. Du kan även lämna över kontrollen till en annan enhet mitt under gudstjänsten.",
-  "faq_q14": "Vilka språk har gränssnittet och var lagras vår data?",
-  "faq_a14": "Gränssnittet finns idag på engelska och svenska. All data – sånger, presentationer, bilder och uppladdade filer – lagras på din egen server (PostgreSQL plus ett S3-kompatibelt objektlager). Ingen data skickas till oss eller någon tredje part.",
-  "faq_q15": "Vad innebär \"Alpha\"?",
-  "faq_a15": "Gospel Presenter är under aktiv utveckling. Det betyder att funktioner tillkommer löpande, att saker kan ändras och att buggar kan förekomma. Prova gärna verktyget, men räkna med att det fortfarande mognar. Återkoppling hjälper oss att prioritera rätt.",
-  "faq_q16": "Hur kan jag bidra eller rapportera fel?",
-  "faq_a16": "All utveckling sker öppet på GitHub. Där kan du rapportera buggar, föreslå funktioner eller bidra med kod. Pull requests och feedback är välkomna.",
-  "faq_q17": "Finns det experimentella eller AI-relaterade funktioner?",
-  "faq_a17": "Ja. Gospel Presenter har en inbyggd MCP-server (Model Context Protocol) som låter AI-assistenter som Claude arbeta direkt med dina presentationer – t.ex. lista, skapa eller redigera dem, hämta sångtexter eller söka i bibeln. Det innebär att du kan ta hjälp av AI för att snabbt sätta ihop en presentation utifrån dagens predikan eller sångrepertoar. Funktionen är experimentell och under utveckling."
+  "faq_q14": "Vilka språk har gränssnittet?",
+  "faq_a14": "Gränssnittet finns idag på engelska och svenska.",
+  "faq_q15": "Var lagras vår data?",
+  "faq_a15": "All data – sånger, presentationer, bilder och uppladdade filer – lagras på din egen server (PostgreSQL plus ett S3-kompatibelt objektlager). Ingen data skickas till oss eller någon tredje part.",
+  "faq_q16": "Vad innebär \"Alpha\"?",
+  "faq_a16": "Gospel Presenter är under aktiv utveckling. Det betyder att funktioner tillkommer löpande, att saker kan ändras och att buggar kan förekomma. Prova gärna verktyget, men räkna med att det fortfarande mognar. Återkoppling hjälper oss att prioritera rätt.",
+  "faq_q17": "Hur kan jag bidra eller rapportera fel?",
+  "faq_a17": "All utveckling sker öppet på GitHub. Där kan du rapportera buggar, föreslå funktioner eller bidra med kod. Pull requests och feedback är välkomna.",
+  "faq_q18": "Finns det experimentella eller AI-relaterade funktioner?",
+  "faq_a18": "Ja. Gospel Presenter har en inbyggd MCP-server (Model Context Protocol) som låter AI-assistenter som Claude arbeta direkt med dina presentationer – t.ex. lista, skapa eller redigera dem, hämta sångtexter eller söka i bibeln. Det innebär att du kan ta hjälp av AI för att snabbt sätta ihop en presentation utifrån dagens predikan eller sångrepertoar. Funktionen är experimentell och under utveckling."
 }


### PR DESCRIPTION
## Summary
- Splits the previous Q14 (\"Which languages does the interface have, and where is our data stored?\") into two separate questions, since the topics are unrelated.
- Q14 now covers UI languages only; new Q15 covers data storage. Existing Q15 (Alpha) and Q16 (contributing) shift to Q16 and Q17.

## Test plan
- [ ] `cd docs && npm run dev` — confirm 17 FAQ entries render in EN and SV
- [ ] Expand each split entry and verify the wording reads naturally on its own