### PR TITLE
Add FAQ entry about experimental MCP / AI integration

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -291,6 +291,13 @@
             </summary>
             <p class="pb-5 text-slate-600 dark:text-slate-400">{{faq_a16}}</p>
           </details>
+          <details class="group border-b border-slate-200 dark:border-neutral-800">
+            <summary class="flex items-center justify-between gap-4 py-5 cursor-pointer list-none [&::-webkit-details-marker]:hidden font-medium text-neutral-800 dark:text-neutral-100">
+              <span>{{faq_q17}}</span>
+              <svg class="w-5 h-5 text-sky-500 transition-transform group-open:rotate-180 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+            </summary>
+            <p class="pb-5 text-slate-600 dark:text-slate-400">{{faq_a17}}</p>
+          </details>
         </div>
       </div>
 

--- a/docs/src/i18n/en.json
+++ b/docs/src/i18n/en.json
@@ -67,5 +67,7 @@
   "faq_q15": "What does \"Alpha\" mean?",
   "faq_a15": "Gospel Presenter is under active development. That means features are added continuously, things may change, and bugs may occur. Feel free to try the tool, but expect it to still be maturing. Feedback helps us prioritize.",
   "faq_q16": "How can I contribute or report bugs?",
-  "faq_a16": "All development happens openly on GitHub. There you can report bugs, suggest features, or contribute code. Pull requests and feedback are welcome."
+  "faq_a16": "All development happens openly on GitHub. There you can report bugs, suggest features, or contribute code. Pull requests and feedback are welcome.",
+  "faq_q17": "Are there any experimental or AI-related features?",
+  "faq_a17": "Yes. Gospel Presenter has a built-in MCP server (Model Context Protocol) that lets AI assistants like Claude work directly with your presentations — for example listing, creating, or editing them, fetching song lyrics, or searching the Bible. That means you can use AI to quickly put together a presentation based on the day's sermon or song repertoire. The feature is experimental and under development."
 }

--- a/docs/src/i18n/sv.json
+++ b/docs/src/i18n/sv.json
@@ -67,5 +67,7 @@
   "faq_q15": "Vad innebär \"Alpha\"?",
   "faq_a15": "Gospel Presenter är under aktiv utveckling. Det betyder att funktioner tillkommer löpande, att saker kan ändras och att buggar kan förekomma. Prova gärna verktyget, men räkna med att det fortfarande mognar. Återkoppling hjälper oss att prioritera rätt.",
   "faq_q16": "Hur kan jag bidra eller rapportera fel?",
-  "faq_a16": "All utveckling sker öppet på GitHub. Där kan du rapportera buggar, föreslå funktioner eller bidra med kod. Pull requests och feedback är välkomna."
+  "faq_a16": "All utveckling sker öppet på GitHub. Där kan du rapportera buggar, föreslå funktioner eller bidra med kod. Pull requests och feedback är välkomna.",
+  "faq_q17": "Finns det experimentella eller AI-relaterade funktioner?",
+  "faq_a17": "Ja. Gospel Presenter har en inbyggd MCP-server (Model Context Protocol) som låter AI-assistenter som Claude arbeta direkt med dina presentationer – t.ex. lista, skapa eller redigera dem, hämta sångtexter eller söka i bibeln. Det innebär att du kan ta hjälp av AI för att snabbt sätta ihop en presentation utifrån dagens predikan eller sångrepertoar. Funktionen är experimentell och under utveckling."
 }


### PR DESCRIPTION
## Summary
- Adds Q17 to the FAQ describing the built-in MCP (Model Context Protocol) server and how AI assistants like Claude can be used to put together presentations based on the day's sermon or song repertoire.
- Honest framing: explicitly marked as experimental and under development.
- Appended at the end (rather than inserted near \"Alpha\") to avoid renumbering and merge conflicts with PRs #20 and #21.

## Test plan
- [ ] Expand Q17 in EN and SV and verify the wording reads naturally