### PR TITLE
Add QR code and URL instructions to temporary screen pairing modal

### DIFF
--- a/GospelPresenter/GospelPresenter.Shared/Components/Presentations/PairingCodeDialog.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Presentations/PairingCodeDialog.razor
@@ -1,27 +1,57 @@
 @using GospelPresenter.Shared.State
+@using QRCoder
+@implements IDisposable
 
 @inject RemoteDisplayState RemoteDisplayState
+@inject NavigationManager NavigationManager
 
 <Dialog Class="bg-white dark:bg-neutral-800 max-w-sm" OnClose="OnClose">
-    <div class="p-6 space-y-4">
+    <div class="p-6 space-y-5">
         <div class="font-semibold text-lg">@L["LivePanel.AddTempDisplayTitle"]</div>
-        <div class="text-sm text-neutral-500 dark:text-neutral-400">@L["LivePanel.PairingCodeHint"]</div>
-        <div class="flex justify-center gap-3">
-            @for (var i = 0; i < 4; i++)
-            {
-                var index = i;
-                <input type="text"
-                       @ref="digitInputs[index]"
-                       inputmode="numeric"
-                       pattern="[0-9]*"
-                       maxlength="1"
-                       autocomplete="off"
-                       value="@GetDigit(index)"
-                       @oninput="e => OnDigitInput(index, e)"
-                       @onkeydown="e => OnDigitKeyDown(index, e)"
-                       class="w-12 h-14 text-center text-2xl font-bold font-mono rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-sky-500"/>
-            }
+
+        <div class="space-y-3">
+            <div class="font-medium text-sm text-neutral-800 dark:text-neutral-100">@L["LivePanel.PairScanQrTitle"]</div>
+            <div class="text-sm text-neutral-500 dark:text-neutral-400">@L["LivePanel.PairScanQrHint"]</div>
+            <div class="flex justify-center">
+                <div class="bg-white p-3 rounded-lg w-48 h-48 flex items-center justify-center [&>svg]:w-full [&>svg]:h-full">
+                    @if (qrSvg is not null)
+                    {
+                        @((MarkupString)qrSvg)
+                    }
+                </div>
+            </div>
         </div>
+
+        <div class="flex items-center gap-3">
+            <div class="h-px flex-1 bg-neutral-200 dark:bg-neutral-700"></div>
+            <span class="text-xs uppercase tracking-widest text-neutral-400 dark:text-neutral-500">@L["LivePanel.PairOr"]</span>
+            <div class="h-px flex-1 bg-neutral-200 dark:bg-neutral-700"></div>
+        </div>
+
+        <div class="space-y-3">
+            <div class="font-medium text-sm text-neutral-800 dark:text-neutral-100">@L["LivePanel.PairManualTitle"]</div>
+            <div class="text-sm text-neutral-500 dark:text-neutral-400">@L["LivePanel.PairManualHint"]</div>
+            <div class="flex justify-center">
+                <code class="px-3 py-1.5 rounded-md bg-neutral-100 dark:bg-neutral-700 text-sm font-mono text-neutral-800 dark:text-neutral-100 select-all break-all">@displayUrl</code>
+            </div>
+            <div class="flex justify-center gap-3">
+                @for (var i = 0; i < 4; i++)
+                {
+                    var index = i;
+                    <input type="text"
+                           @ref="digitInputs[index]"
+                           inputmode="numeric"
+                           pattern="[0-9]*"
+                           maxlength="1"
+                           autocomplete="off"
+                           value="@GetDigit(index)"
+                           @oninput="e => OnDigitInput(index, e)"
+                           @onkeydown="e => OnDigitKeyDown(index, e)"
+                           class="w-12 h-14 text-center text-2xl font-bold font-mono rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-sky-500"/>
+                }
+            </div>
+        </div>
+
         @if (error is not null)
         {
             <div class="text-sm text-red-500 dark:text-red-400">@error</div>
@@ -42,17 +72,54 @@
     [Parameter] public EventCallback OnClose { get; set; }
     [Parameter] public EventCallback OnPaired { get; set; }
 
+    private static readonly TimeSpan TokenRefreshInterval = TimeSpan.FromMinutes(8);
+
     private char[] digits = new char[4];
     private ElementReference[] digitInputs = new ElementReference[4];
     private string? error;
     private bool pairing;
     private bool shouldFocus = true;
 
+    private string? currentToken;
+    private string displayUrl = "";
+    private string? qrSvg;
+    private Timer? tokenRefreshTimer;
+
     private string Code => new string(digits);
     private bool IsComplete => digits.All(char.IsDigit);
 
     private string GetDigit(int index) =>
         digits[index] == '\0' ? "" : digits[index].ToString();
+
+    protected override void OnInitialized()
+    {
+        var baseUri = new Uri(NavigationManager.BaseUri);
+        displayUrl = new Uri(baseUri, "display").ToString().TrimEnd('/');
+
+        RegenerateToken();
+        tokenRefreshTimer = new Timer(_ => RegenerateToken(), null, TokenRefreshInterval, TokenRefreshInterval);
+    }
+
+    private void RegenerateToken()
+    {
+        if (currentToken is not null)
+            RemoteDisplayState.InvalidatePairingToken(currentToken);
+
+        currentToken = RemoteDisplayState.GeneratePairingToken(SessionId);
+
+        var pairingUrl = $"{displayUrl}?token={currentToken}";
+        qrSvg = BuildQrSvg(pairingUrl);
+
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private static string BuildQrSvg(string url)
+    {
+        using var qrGenerator = new QRCodeGenerator();
+        using var qrData = qrGenerator.CreateQrCode(url, QRCodeGenerator.ECCLevel.M);
+        var svgQrCode = new SvgQRCode(qrData);
+        return svgQrCode.GetGraphic(4);
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -157,5 +224,12 @@
 
         digits = new char[4];
         pairing = false;
+    }
+
+    public void Dispose()
+    {
+        tokenRefreshTimer?.Dispose();
+        if (currentToken is not null)
+            RemoteDisplayState.InvalidatePairingToken(currentToken);
     }
 }

--- a/GospelPresenter/GospelPresenter.Shared/GospelPresenter.Shared.csproj
+++ b/GospelPresenter/GospelPresenter.Shared/GospelPresenter.Shared.csproj
@@ -39,6 +39,7 @@
         <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.5" />
         <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.11" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+        <PackageReference Include="QRCoder" Version="1.6.0" />
         <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
         <PackageReference Include="SkiaSharp" Version="3.119.2" />
         <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />

--- a/GospelPresenter/GospelPresenter.Shared/Pages/Display.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Pages/Display.razor
@@ -89,6 +89,7 @@ else
     private string pairingCode = "";
     private string? pairedSessionId;
     private string? displayName;
+    private string? autoPairToken;
     private bool fullscreenRequested;
     private bool initialized;
     private Timer? codeRefreshTimer;
@@ -125,6 +126,10 @@ else
         {
             stableDisplayId = id.ToString();
             displayId = stableDisplayId;
+        }
+        else if (query.TryGetValue("token", out var token))
+        {
+            autoPairToken = token.ToString();
         }
 
         JsRuntime.InvokeVoidAsync("setRootElementBackgroundColor", "black");
@@ -167,7 +172,14 @@ else
 
             RemoteDisplayState.RegisterDisplayOnline(displayId);
 
-            // Check if still paired from before reload
+            if (autoPairToken is not null)
+            {
+                RemoteDisplayState.ConsumePairingToken(autoPairToken, displayId, displayName);
+                autoPairToken = null;
+                await JsRuntime.InvokeVoidAsync("history.replaceState", null, "", "/display");
+            }
+
+            // Check if still paired (either from before reload or via auto-pair token)
             if (RemoteDisplayState.IsDisplayConnected(displayId))
             {
                 pairedSessionId = RemoteDisplayState.GetSessionForDisplay(displayId);

--- a/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.resx
+++ b/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.resx
@@ -1550,6 +1550,21 @@
   <data name="LivePanel.PairingCodePlaceholder" xml:space="preserve">
     <value>Enter 4-digit code</value>
   </data>
+  <data name="LivePanel.PairScanQrTitle" xml:space="preserve">
+    <value>Scan the QR code</value>
+  </data>
+  <data name="LivePanel.PairScanQrHint" xml:space="preserve">
+    <value>Scan with the camera on the device you want to use as a display — it connects automatically.</value>
+  </data>
+  <data name="LivePanel.PairOr" xml:space="preserve">
+    <value>or</value>
+  </data>
+  <data name="LivePanel.PairManualTitle" xml:space="preserve">
+    <value>Or enter the code manually</value>
+  </data>
+  <data name="LivePanel.PairManualHint" xml:space="preserve">
+    <value>Open the URL below on the screen device and enter the code shown there.</value>
+  </data>
   <data name="LivePanel.ToggleCollapsed" xml:space="preserve">
     <value>Toggle live panel</value>
   </data>

--- a/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.sv.resx
+++ b/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.sv.resx
@@ -1550,6 +1550,21 @@
   <data name="LivePanel.PairingCodePlaceholder" xml:space="preserve">
     <value>Ange 4-siffrig kod</value>
   </data>
+  <data name="LivePanel.PairScanQrTitle" xml:space="preserve">
+    <value>Skanna QR-koden</value>
+  </data>
+  <data name="LivePanel.PairScanQrHint" xml:space="preserve">
+    <value>Skanna med kameran på enheten du vill använda som skärm — den ansluts automatiskt.</value>
+  </data>
+  <data name="LivePanel.PairOr" xml:space="preserve">
+    <value>eller</value>
+  </data>
+  <data name="LivePanel.PairManualTitle" xml:space="preserve">
+    <value>Eller skriv in koden manuellt</value>
+  </data>
+  <data name="LivePanel.PairManualHint" xml:space="preserve">
+    <value>Öppna adressen nedan på skärmenheten och skriv in koden som visas där.</value>
+  </data>
   <data name="LivePanel.ToggleCollapsed" xml:space="preserve">
     <value>Fäll in eller ut live-vyn</value>
   </data>

--- a/GospelPresenter/GospelPresenter.Shared/State/RemoteDisplayState.cs
+++ b/GospelPresenter/GospelPresenter.Shared/State/RemoteDisplayState.cs
@@ -5,6 +5,8 @@ namespace GospelPresenter.Shared.State;
 
 public record PairingEntry(string DisplayId, DateTime CreatedAt);
 
+public record PairingTokenEntry(string SessionId, DateTime CreatedAt);
+
 public record ConnectedDisplay(string DisplayId, string Name);
 
 public class RemoteDisplayState
@@ -13,6 +15,7 @@ public class RemoteDisplayState
     private static readonly TimeSpan IdleTimeout = TimeSpan.FromHours(4);
 
     private readonly ConcurrentDictionary<string, PairingEntry> pairingCodes = new();
+    private readonly ConcurrentDictionary<string, PairingTokenEntry> pairingTokens = new();
     private readonly ConcurrentDictionary<string, string> displayToSession = new();
     private readonly ConcurrentDictionary<string, string> displayToCode = new();
     private readonly ConcurrentDictionary<string, string> displayToName = new();
@@ -53,6 +56,43 @@ public class RemoteDisplayState
 
         displayToCode[displayId] = code;
         return code;
+    }
+
+    public string GeneratePairingToken(string sessionId)
+    {
+        CleanupExpiredTokens();
+
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        var token = Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+
+        pairingTokens[token] = new PairingTokenEntry(sessionId, DateTime.UtcNow);
+        return token;
+    }
+
+    public void InvalidatePairingToken(string token)
+    {
+        pairingTokens.TryRemove(token, out _);
+    }
+
+    public bool ConsumePairingToken(string token, string displayId, string? displayName = null)
+    {
+        if (!pairingTokens.TryRemove(token, out var entry))
+            return false;
+
+        if (DateTime.UtcNow - entry.CreatedAt > CodeExpiration)
+            return false;
+
+        var now = DateTime.UtcNow;
+        displayToSession[displayId] = entry.SessionId;
+        displayPairedAt[displayId] = now;
+        displayLastActivity[displayId] = now;
+        if (displayName is not null)
+            displayToName[displayId] = displayName;
+        DisplayPaired?.Invoke(displayId);
+        return true;
     }
 
     public bool PairDisplay(string code, string sessionId, string? name = null)
@@ -210,6 +250,16 @@ public class RemoteDisplayState
                 pairingCodes.TryRemove(code, out _);
                 displayToCode.TryRemove(entry.DisplayId, out _);
             }
+        }
+    }
+
+    private void CleanupExpiredTokens()
+    {
+        var now = DateTime.UtcNow;
+        foreach (var (token, entry) in pairingTokens)
+        {
+            if (now - entry.CreatedAt > CodeExpiration)
+                pairingTokens.TryRemove(token, out _);
         }
     }
 }

--- a/GospelPresenter/GospelPresenter.UnitTests/State/RemoteDisplayStateTests.cs
+++ b/GospelPresenter/GospelPresenter.UnitTests/State/RemoteDisplayStateTests.cs
@@ -241,4 +241,66 @@ public class RemoteDisplayStateTests
     {
         state.IsDisplayConnected("unknown").ShouldBeFalse();
     }
+
+    [Fact]
+    public void GeneratePairingToken_ReturnsUniqueTokens()
+    {
+        var token1 = state.GeneratePairingToken("session-1");
+        var token2 = state.GeneratePairingToken("session-1");
+
+        token1.ShouldNotBe(token2);
+        token1.Length.ShouldBeGreaterThan(20);
+    }
+
+    [Fact]
+    public void ConsumePairingToken_WithValidToken_BindsDisplayToSession()
+    {
+        var token = state.GeneratePairingToken("session-1");
+
+        var result = state.ConsumePairingToken(token, "display-1", "Main Hall");
+
+        result.ShouldBeTrue();
+        state.GetSessionForDisplay("display-1").ShouldBe("session-1");
+        state.GetDisplayName("display-1").ShouldBe("Main Hall");
+    }
+
+    [Fact]
+    public void ConsumePairingToken_WithInvalidToken_ReturnsFalse()
+    {
+        var result = state.ConsumePairingToken("not-a-real-token", "display-1");
+
+        result.ShouldBeFalse();
+        state.IsDisplayConnected("display-1").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ConsumePairingToken_SameTokenTwice_FailsSecondTime()
+    {
+        var token = state.GeneratePairingToken("session-1");
+
+        state.ConsumePairingToken(token, "display-1").ShouldBeTrue();
+        state.ConsumePairingToken(token, "display-2").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ConsumePairingToken_FiresDisplayPairedEvent()
+    {
+        string? pairedId = null;
+        state.DisplayPaired += id => pairedId = id;
+
+        var token = state.GeneratePairingToken("session-1");
+        state.ConsumePairingToken(token, "display-1");
+
+        pairedId.ShouldBe("display-1");
+    }
+
+    [Fact]
+    public void InvalidatePairingToken_PreventsConsumption()
+    {
+        var token = state.GeneratePairingToken("session-1");
+
+        state.InvalidatePairingToken(token);
+
+        state.ConsumePairingToken(token, "display-1").ShouldBeFalse();
+    }
 }


### PR DESCRIPTION
The "Tillfällig skärm" modal now offers two clearly separated paths to
pair a display: scan a QR code for automatic pairing, or open the
displayed URL on the device and enter the code manually. The QR encodes
a one-time, cryptographically random pairing token bound to the
controller's session and expiring after 10 minutes; a timer in the
dialog regenerates the token every 8 minutes (revoking the previous
one) so an open dialog never shows a stale QR.

https://claude.ai/code/session_01VCosoPT9DxSGfr8H3zFNi9