### PR TITLE
Add Playwright E2E tests for remote display pairing

### DIFF
--- a/GospelPresenter/GospelPresenter.E2ETests/Dockerfile
+++ b/GospelPresenter/GospelPresenter.E2ETests/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY ["GospelPresenter.E2ETests/GospelPresenter.E2ETests.csproj", "GospelPresenter.E2ETests/"]
+RUN dotnet restore "GospelPresenter.E2ETests/GospelPresenter.E2ETests.csproj"
+COPY . .
+WORKDIR "/src/GospelPresenter.E2ETests"
+RUN dotnet publish "GospelPresenter.E2ETests.csproj" \
+    -c Release \
+    -o /app/publish \
+    --self-contained false
+
+FROM mcr.microsoft.com/playwright/dotnet:v1.52.0-noble AS final
+RUN apt-get update && apt-get install -y --no-install-recommends libfontconfig1 && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV E2E_BASE_URL=http://web:8080
+ENTRYPOINT ["dotnet", "test", "GospelPresenter.E2ETests.dll", "--logger:console;verbosity=normal"]

--- a/GospelPresenter/GospelPresenter.E2ETests/Fixtures/PageHelpers.cs
+++ b/GospelPresenter/GospelPresenter.E2ETests/Fixtures/PageHelpers.cs
@@ -1,0 +1,81 @@
+using Microsoft.Playwright;
+
+namespace GospelPresenter.E2ETests.Fixtures;
+
+public static class PageHelpers
+{
+    // crypto.randomUUID is only available in secure contexts. The app is reached over plain
+    // HTTP via a docker-compose hostname, so polyfill it from crypto.getRandomValues.
+    private const string CryptoRandomUuidPolyfill = """
+        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID !== 'function') {
+            crypto.randomUUID = function () {
+                const bytes = new Uint8Array(16);
+                crypto.getRandomValues(bytes);
+                bytes[6] = (bytes[6] & 0x0f) | 0x40;
+                bytes[8] = (bytes[8] & 0x3f) | 0x80;
+                const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+                return hex.slice(0,8) + '-' + hex.slice(8,12) + '-' + hex.slice(12,16) + '-' + hex.slice(16,20) + '-' + hex.slice(20);
+            };
+        }
+        """;
+
+    public static Task AddBrowserPolyfillsAsync(IBrowserContext context) =>
+        context.AddInitScriptAsync(CryptoRandomUuidPolyfill);
+
+    public static Task AddMockAuthCookiesAsync(IBrowserContext context, string baseUrl, string mockUserId, string lang)
+    {
+        var domain = new Uri(baseUrl).Host;
+        return context.AddCookiesAsync(
+        [
+            new Cookie { Name = ".AspNetCore.Culture", Value = $"c={lang}|uic={lang}", Domain = domain, Path = "/" },
+            new Cookie { Name = "mock-user-id", Value = mockUserId, Domain = domain, Path = "/" }
+        ]);
+    }
+
+    public static async Task WaitForWebAppAsync(string baseUrl, int timeoutSeconds = 60, CancellationToken cancellationToken = default)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        Exception? lastError = null;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var response = await http.GetAsync(baseUrl, cancellationToken);
+                if (response.IsSuccessStatusCode) return;
+                lastError = new InvalidOperationException($"HTTP {(int)response.StatusCode}");
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                lastError = ex;
+            }
+            await Task.Delay(1000, cancellationToken);
+        }
+
+        throw new TimeoutException($"Web app at {baseUrl} did not become ready within {timeoutSeconds}s. Last error: {lastError?.Message}");
+    }
+
+    public static async Task WaitForBlazorAsync(IPage page)
+    {
+        await page.WaitForFunctionAsync("() => document.readyState === 'complete'");
+        // Brief settle for CSS transitions and Blazor circuit hookup; no reliable DOM signal.
+        await page.WaitForTimeoutAsync(300);
+    }
+
+    public static async Task<string> DiscoverPresentationIdAsync(IPage page, string baseUrl)
+    {
+        await page.GotoAsync(baseUrl, new PageGotoOptions { WaitUntil = WaitUntilState.Load });
+        await WaitForBlazorAsync(page);
+
+        var link = page.Locator("a[href^='/presentations/']").First;
+        await link.WaitForAsync(new LocatorWaitForOptions { Timeout = 10_000 });
+
+        var href = await link.GetAttributeAsync("href")
+            ?? throw new InvalidOperationException("Presentation link found but has no href attribute.");
+
+        var path = new Uri(href, UriKind.Relative).ToString().Split('?')[0].Split('#')[0];
+        return path.TrimEnd('/').Split('/').Last();
+    }
+}

--- a/GospelPresenter/GospelPresenter.E2ETests/Fixtures/PlaywrightFixture.cs
+++ b/GospelPresenter/GospelPresenter.E2ETests/Fixtures/PlaywrightFixture.cs
@@ -1,0 +1,62 @@
+using Microsoft.Playwright;
+
+namespace GospelPresenter.E2ETests.Fixtures;
+
+// Owns the Playwright runtime and a single browser for the whole test run.
+// Tests should request a fresh IBrowserContext per scenario via NewControllerContextAsync /
+// NewDisplayContextAsync to keep cookies and storage isolated.
+public class PlaywrightFixture : IAsyncLifetime
+{
+    public string BaseUrl { get; private set; } = "";
+    public IPlaywright Playwright { get; private set; } = null!;
+    public IBrowser Browser { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        BaseUrl = (Environment.GetEnvironmentVariable("E2E_BASE_URL") ?? "http://localhost:8080").TrimEnd('/');
+
+        await PageHelpers.WaitForWebAppAsync(BaseUrl);
+
+        Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+        Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = !string.Equals(Environment.GetEnvironmentVariable("E2E_HEADED"), "true", StringComparison.OrdinalIgnoreCase),
+            // Treat the base URL as a secure context so browser APIs like crypto.randomUUID
+            // work over plain HTTP (e.g. when the app is reached via a docker-compose hostname).
+            Args = [$"--unsafely-treat-insecure-origin-as-secure={BaseUrl}"]
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (Browser is not null) await Browser.DisposeAsync();
+        Playwright?.Dispose();
+    }
+
+    public async Task<IBrowserContext> NewControllerContextAsync(string mockUserId = "mock-user-en", string lang = "en")
+    {
+        var context = await Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize { Width = 1440, Height = 900 }
+        });
+        await PageHelpers.AddBrowserPolyfillsAsync(context);
+        await PageHelpers.AddMockAuthCookiesAsync(context, BaseUrl, mockUserId, lang);
+        return context;
+    }
+
+    public async Task<IBrowserContext> NewDisplayContextAsync()
+    {
+        var context = await Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            ViewportSize = new ViewportSize { Width = 1280, Height = 720 }
+        });
+        await PageHelpers.AddBrowserPolyfillsAsync(context);
+        return context;
+    }
+}
+
+[CollectionDefinition(Name)]
+public class PlaywrightCollection : ICollectionFixture<PlaywrightFixture>
+{
+    public const string Name = "Playwright";
+}

--- a/GospelPresenter/GospelPresenter.E2ETests/Fixtures/SlideProbe.cs
+++ b/GospelPresenter/GospelPresenter.E2ETests/Fixtures/SlideProbe.cs
@@ -1,0 +1,25 @@
+using Microsoft.Playwright;
+
+namespace GospelPresenter.E2ETests.Fixtures;
+
+public static class SlideProbe
+{
+    // Pick a 6+ character word from a slide preview to use as a propagation probe.
+    // Avoids short tokens that could collide with app chrome (e.g. menu labels).
+    public static string ExtractProbe(string slideText)
+    {
+        var words = slideText
+            .Split([' ', '\n', '\r', '\t', ',', '.', '!', '?', ';', ':'], StringSplitOptions.RemoveEmptyEntries)
+            .Where(w => w.Length >= 6 && w.All(c => char.IsLetter(c) || c == '\''))
+            .ToList();
+        return words.FirstOrDefault() ?? slideText.Trim();
+    }
+
+    public static Task WaitForProbeOnPageAsync(IPage page, string probe, float timeoutMs = 5_000)
+    {
+        var escaped = probe.Replace("\\", "\\\\").Replace("'", "\\'");
+        return page.WaitForFunctionAsync(
+            $"() => document.body.textContent.includes('{escaped}')",
+            new PageWaitForFunctionOptions { Timeout = timeoutMs });
+    }
+}

--- a/GospelPresenter/GospelPresenter.E2ETests/GospelPresenter.E2ETests.csproj
+++ b/GospelPresenter/GospelPresenter.E2ETests/GospelPresenter.E2ETests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <!-- Pinned to net8.0 to match the runtime in mcr.microsoft.com/playwright/dotnet:v1.52.0. -->
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.Playwright" Version="1.52.0" />
+        <PackageReference Include="Shouldly" Version="4.3.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+</Project>

--- a/GospelPresenter/GospelPresenter.E2ETests/Tests/RemoteDisplayPairingTests.cs
+++ b/GospelPresenter/GospelPresenter.E2ETests/Tests/RemoteDisplayPairingTests.cs
@@ -1,0 +1,159 @@
+using System.Text.RegularExpressions;
+using GospelPresenter.E2ETests.Fixtures;
+using Microsoft.Playwright;
+using Shouldly;
+
+namespace GospelPresenter.E2ETests.Tests;
+
+[Collection(PlaywrightCollection.Name)]
+public class RemoteDisplayPairingTests(PlaywrightFixture fixture)
+{
+    [Fact]
+    public async Task AdHocDisplay_PairsWithControllerViaCode_AndReportsSuccess()
+    {
+        await using var session = await PairAdHocDisplayAsync();
+
+        // The dialog flips to its success state once pairing succeeds.
+        await session.Controller
+            .GetByText("Display connected").Or(session.Controller.GetByText("Skärmen är ansluten"))
+            .WaitForAsync(new LocatorWaitForOptions { Timeout = 5_000 });
+
+        // The display device leaves the pairing-code screen — the code is no longer in the DOM.
+        await session.Display.WaitForFunctionAsync(
+            "() => !document.body.textContent.includes('Pairing code') && !document.body.textContent.includes('Parkopplingskod')",
+            new PageWaitForFunctionOptions { Timeout = 5_000 });
+    }
+
+    [Fact]
+    public async Task LiveSlideChanges_PropagateFromControllerToDisplay()
+    {
+        await using var session = await PairAdHocDisplayAsync();
+
+        // Close the success dialog so we can interact with the slide list underneath.
+        await session.Controller.GetByRole(AriaRole.Button, new() { Name = "Close" })
+            .ClickAsync(new LocatorClickOptions { Timeout = 5_000 });
+
+        // Capture the text from the first slide preview, then click it to make it the live slide.
+        var firstSlide = session.Controller.Locator("#main button").First;
+        await firstSlide.WaitForAsync(new LocatorWaitForOptions { Timeout = 5_000 });
+        var slideText = await firstSlide.InnerTextAsync();
+
+        var probe = SlideProbe.ExtractProbe(slideText);
+        probe.ShouldNotBeNullOrEmpty($"Could not extract a probe phrase from slide text: {slideText}");
+
+        await firstSlide.ClickAsync(new LocatorClickOptions { Force = true });
+
+        // Wait for the same text to appear on the paired display, confirming SignalR propagation.
+        await SlideProbe.WaitForProbeOnPageAsync(session.Display, probe);
+    }
+
+    [Fact]
+    public async Task AdHocDisplay_SurvivesPageReload()
+    {
+        await using var session = await PairAdHocDisplayAsync();
+
+        // Wait for the success state on the controller so we know pairing is fully committed.
+        await session.Controller
+            .GetByText("Display connected").Or(session.Controller.GetByText("Skärmen är ansluten"))
+            .WaitForAsync(new LocatorWaitForOptions { Timeout = 5_000 });
+
+        // Reload the display page. sessionStorage keeps the ad-hoc displayId, so the server-side
+        // pairing should still match and the display should not fall back to a fresh code.
+        await session.Display.ReloadAsync(new PageReloadOptions { WaitUntil = WaitUntilState.Load });
+        await PageHelpers.WaitForBlazorAsync(session.Display);
+
+        await session.Display.WaitForFunctionAsync(
+            "() => !document.body.textContent.includes('Pairing code') && !document.body.textContent.includes('Parkopplingskod')",
+            new PageWaitForFunctionOptions { Timeout = 5_000 });
+    }
+
+    [Fact]
+    public async Task ControllerDisconnect_RevertsAdHocDisplayToPairingCode()
+    {
+        await using var session = await PairAdHocDisplayAsync();
+
+        // Close the pairing-success dialog to expose the LivePanel that lists connected displays.
+        await session.Controller.GetByRole(AriaRole.Button, new() { Name = "Close" })
+            .ClickAsync(new LocatorClickOptions { Timeout = 5_000 });
+
+        // Click the disconnect button next to the connected ad-hoc display row.
+        // The page renders both a mobile and a desktop LivePanel — :visible skips the one
+        // hidden via Tailwind's responsive utilities so .First lands on the active panel.
+        await session.Controller.Locator("button[title='Disconnect']:visible").First
+            .ClickAsync(new LocatorClickOptions { Timeout = 5_000 });
+
+        // The display should fall back to a fresh 4-digit pairing code.
+        await session.Display.WaitForFunctionAsync(
+            "() => /\\b\\d{4}\\b/.test(document.body.textContent) && (document.body.textContent.includes('Pairing code') || document.body.textContent.includes('Parkopplingskod'))",
+            new PageWaitForFunctionOptions { Timeout = 5_000 });
+    }
+
+    private async Task<PairedSession> PairAdHocDisplayAsync()
+    {
+        var displayContext = await fixture.NewDisplayContextAsync();
+        var controllerContext = await fixture.NewControllerContextAsync();
+
+        var displayPage = await displayContext.NewPageAsync();
+        var controllerPage = await controllerContext.NewPageAsync();
+
+        // Display device opens /display and shows a 4-digit pairing code.
+        await displayPage.GotoAsync($"{fixture.BaseUrl}/display", new PageGotoOptions { WaitUntil = WaitUntilState.Load });
+        await PageHelpers.WaitForBlazorAsync(displayPage);
+
+        var pairingCode = await ReadPairingCodeAsync(displayPage);
+        pairingCode.ShouldMatch(@"^\d{4}$");
+
+        // Controller opens a presentation, starts it, and opens the pairing dialog.
+        var presentationId = await PageHelpers.DiscoverPresentationIdAsync(controllerPage, fixture.BaseUrl);
+        await controllerPage.GotoAsync($"{fixture.BaseUrl}/presentations/{presentationId}",
+            new PageGotoOptions { WaitUntil = WaitUntilState.Load });
+        await PageHelpers.WaitForBlazorAsync(controllerPage);
+
+        await controllerPage.Locator("[data-id]").First.ClickAsync(new LocatorClickOptions { Timeout = 5_000 });
+
+        var startButton = controllerPage.Locator("button[title='Start presentation']");
+        if (await startButton.CountAsync() > 0)
+        {
+            await startButton.First.ClickAsync(new LocatorClickOptions { Force = true });
+            await controllerPage.WaitForTimeoutAsync(300);
+        }
+
+        await controllerPage.GetByRole(AriaRole.Button, new() { Name = "Add output" })
+            .ClickAsync(new LocatorClickOptions { Timeout = 5_000 });
+        await controllerPage.GetByRole(AriaRole.Button, new() { Name = "Temporary display" })
+            .ClickAsync(new LocatorClickOptions { Timeout = 5_000 });
+
+        // Type the 4 digits into the pairing dialog.
+        var digitInputs = controllerPage.Locator("input[maxlength='1'][inputmode='numeric']");
+        await digitInputs.First.WaitForAsync(new LocatorWaitForOptions { Timeout = 5_000 });
+        for (var i = 0; i < 4; i++)
+        {
+            await digitInputs.Nth(i).FillAsync(pairingCode[i].ToString());
+        }
+
+        return new PairedSession(controllerContext, displayContext, controllerPage, displayPage);
+    }
+
+    private static async Task<string> ReadPairingCodeAsync(IPage displayPage)
+    {
+        // Use textContent rather than innerText — innerText depends on rendered layout
+        // and can return empty when the display chrome briefly collapses during re-renders.
+        var bodyText = await displayPage.EvaluateAsync<string>("() => document.body.textContent ?? ''");
+        var match = Regex.Match(bodyText, @"\b(\d{4})\b");
+        match.Success.ShouldBeTrue($"Expected a 4-digit pairing code on /display, body was: {bodyText}");
+        return match.Groups[1].Value;
+    }
+
+    private sealed record PairedSession(
+        IBrowserContext ControllerContext,
+        IBrowserContext DisplayContext,
+        IPage Controller,
+        IPage Display) : IAsyncDisposable
+    {
+        public async ValueTask DisposeAsync()
+        {
+            await ControllerContext.DisposeAsync();
+            await DisplayContext.DisposeAsync();
+        }
+    }
+}

--- a/GospelPresenter/GospelPresenter.E2ETests/Tests/SavedDisplayTests.cs
+++ b/GospelPresenter/GospelPresenter.E2ETests/Tests/SavedDisplayTests.cs
@@ -1,0 +1,70 @@
+using GospelPresenter.E2ETests.Fixtures;
+using Microsoft.Playwright;
+using Shouldly;
+
+namespace GospelPresenter.E2ETests.Tests;
+
+[Collection(PlaywrightCollection.Name)]
+public class SavedDisplayTests(PlaywrightFixture fixture)
+{
+    // The mock-data seeder registers a saved RemoteDisplay called "Sanctuary" with this identifier.
+    private const string SeededDisplayIdentifier = "sanctry";
+    private const string SeededDisplayName = "Sanctuary";
+
+    [Fact]
+    public async Task SavedDisplay_GoesLiveWhenControllerEnablesIt_AndPropagatesSlide()
+    {
+        await using var displayContext = await fixture.NewDisplayContextAsync();
+        await using var controllerContext = await fixture.NewControllerContextAsync();
+
+        var displayPage = await displayContext.NewPageAsync();
+        var controllerPage = await controllerContext.NewPageAsync();
+
+        // Saved display opens its stable URL — the name query param is passed the same way the
+        // controller's QR/copy flow constructs it, so the screen renders the display name.
+        await displayPage.GotoAsync(
+            $"{fixture.BaseUrl}/display?id={SeededDisplayIdentifier}&name={SeededDisplayName}",
+            new PageGotoOptions { WaitUntil = WaitUntilState.Load });
+        await PageHelpers.WaitForBlazorAsync(displayPage);
+
+        // Pre-pair: the display shows its name, no pairing code is rendered.
+        var preBody = await displayPage.EvaluateAsync<string>("() => document.body.textContent ?? ''");
+        preBody.ShouldContain(SeededDisplayName);
+        preBody.ShouldNotContain("Pairing code");
+
+        // Controller opens a presentation and starts it.
+        var presentationId = await PageHelpers.DiscoverPresentationIdAsync(controllerPage, fixture.BaseUrl);
+        await controllerPage.GotoAsync($"{fixture.BaseUrl}/presentations/{presentationId}",
+            new PageGotoOptions { WaitUntil = WaitUntilState.Load });
+        await PageHelpers.WaitForBlazorAsync(controllerPage);
+
+        await controllerPage.Locator("[data-id]").First.ClickAsync(new LocatorClickOptions { Timeout = 5_000 });
+
+        var startButton = controllerPage.Locator("button[title='Start presentation']");
+        if (await startButton.CountAsync() > 0)
+        {
+            await startButton.First.ClickAsync(new LocatorClickOptions { Force = true });
+            await controllerPage.WaitForTimeoutAsync(300);
+        }
+
+        // Toggle the seeded saved display on. Using :visible drops the hidden mobile LivePanel copy.
+        await controllerPage.Locator($"button:visible:has-text('{SeededDisplayName}')").First
+            .ClickAsync(new LocatorClickOptions { Timeout = 5_000 });
+
+        // Display should leave its name-only screen once the controller enables it.
+        await displayPage.WaitForFunctionAsync(
+            $"() => !document.body.textContent.includes('{SeededDisplayName}')",
+            new PageWaitForFunctionOptions { Timeout = 5_000 });
+
+        // Click the first slide and verify the same text reaches the saved display.
+        var firstSlide = controllerPage.Locator("#main button").First;
+        await firstSlide.WaitForAsync(new LocatorWaitForOptions { Timeout = 5_000 });
+        var slideText = await firstSlide.InnerTextAsync();
+        var probe = SlideProbe.ExtractProbe(slideText);
+        probe.ShouldNotBeNullOrEmpty($"Could not extract a probe phrase from slide text: {slideText}");
+
+        await firstSlide.ClickAsync(new LocatorClickOptions { Force = true });
+
+        await SlideProbe.WaitForProbeOnPageAsync(displayPage, probe);
+    }
+}

--- a/GospelPresenter/GospelPresenter.Web/Services/MockDataSeeder.cs
+++ b/GospelPresenter/GospelPresenter.Web/Services/MockDataSeeder.cs
@@ -485,6 +485,14 @@ public static class MockDataSeeder
             VersesJson = BuildBibleVersesJson(svBookCodes),
             VerseCount = svBookCodes.Length
         });
+
+        db.RemoteDisplays.Add(new RemoteDisplay
+        {
+            OrganizationId = org.Id,
+            DisplayIdentifier = "storsal",
+            Name = "Storsalen",
+            CreatedAt = now
+        });
     }
 
     static void SeedEnglish(PresentationContext db, DateTimeOffset now)
@@ -914,6 +922,14 @@ public static class MockDataSeeder
             OrganizationId = org.Id,
             VersesJson = BuildBibleVersesJson(enBookCodes),
             VerseCount = enBookCodes.Length
+        });
+
+        db.RemoteDisplays.Add(new RemoteDisplay
+        {
+            OrganizationId = org.Id,
+            DisplayIdentifier = "sanctry",
+            Name = "Sanctuary",
+            CreatedAt = now
         });
     }
 

--- a/GospelPresenter/GospelPresenter.sln
+++ b/GospelPresenter/GospelPresenter.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GospelPresenter.MigrationSe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GospelPresenter.Screenshots", "GospelPresenter.Screenshots\GospelPresenter.Screenshots.csproj", "{16BC1552-A145-4272-A877-B119EA0318B1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GospelPresenter.E2ETests", "GospelPresenter.E2ETests\GospelPresenter.E2ETests.csproj", "{9801F7F2-127B-4EC5-BF47-57D1BCFC4F42}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +127,18 @@ Global
 		{16BC1552-A145-4272-A877-B119EA0318B1}.Release|x64.Build.0 = Release|Any CPU
 		{16BC1552-A145-4272-A877-B119EA0318B1}.Release|x86.ActiveCfg = Release|Any CPU
 		{16BC1552-A145-4272-A877-B119EA0318B1}.Release|x86.Build.0 = Release|Any CPU
+		{9801F7F2-127B-4EC5-BF47-57D1BCFC4F42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9801F7F2-127B-4EC5-BF47-57D1BCFC4F42}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9801F7F2-127B-4EC5-BF47-57D1BCFC4F42}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9801F7F2-127B-4EC5-BF47-57D1BCFC4F42}.Debug|x64.Build.0 = Debug|Any CPU
+		{9801F7F2-127B-4EC5-BF47-57D1BCFC4F42}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9801F7F2-127B-4EC5-BF47-57D1BCFC4F42}.Debug|x86.Build.0 = Debug|Any CPU
+		{9801F7F2-127B-4EC5-BF47-57D1BCFC4F42}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9801F7F2-127B-4EC5-BF47-57D1BCFC4F42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9801F7F2-127B-4EC5-BF47-57D1BCFC4F42}.Release|x64.ActiveCfg = Release|Any CPU
+		{9801F7F2-127B-4EC5-BF47-57D1BCFC4F42}.Release|x64.Build.0 = Release|Any CPU
+		{9801F7F2-127B-4EC5-BF47-57D1BCFC4F42}.Release|x86.ActiveCfg = Release|Any CPU
+		{9801F7F2-127B-4EC5-BF47-57D1BCFC4F42}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,20 @@
+services:
+  web:
+    platform: linux/amd64
+    build:
+      context: ./GospelPresenter
+      dockerfile: GospelPresenter.Web/Dockerfile
+    container_name: gospelpresenter-e2e-web
+    user: root
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+
+  e2e:
+    build:
+      context: ./GospelPresenter
+      dockerfile: GospelPresenter.E2ETests/Dockerfile
+    container_name: gospelpresenter-e2e-runner
+    depends_on:
+      - web
+    environment:
+      E2E_BASE_URL: http://web:8080


### PR DESCRIPTION
## Summary
- New `GospelPresenter.E2ETests` project (xUnit + Microsoft.Playwright 1.52, targeting net8.0 to match the Playwright dotnet base image)
- Five end-to-end scenarios for the remote control feature, run via `docker-compose.e2e.yml` (Web + Playwright runner sharing a docker network, mock auth via the existing `mock-user-id` cookie)
- `MockDataSeeder` seeds one `RemoteDisplay` per mock org (Sanctuary / Storsalen) so the saved-display flow has a deterministic fixture

## Scenarios covered
- Ad-hoc pairing via 4-digit code — controller dialog reaches the success state, display leaves the pairing-code screen
- Slide changes propagate from controller to display over SignalR
- Display reload preserves pairing (sessionStorage round-trip)
- Controller-initiated disconnect reverts the display to a fresh pairing code
- Saved display goes live when the controller toggles it from the LivePanel, then receives slide updates

## Test plan
- [ ] `docker compose -f docker-compose.e2e.yml up --build --abort-on-container-exit --exit-code-from e2e` — verified locally, 5/5 passing
- [ ] No production code changes beyond the seed additions; mock seeds are guarded by the existing "no users yet" check