### PR TITLE
Add public QR output so visitors can follow along on their own device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -411,3 +411,6 @@ GospelPresenter/songs
 GospelPresenter/GospelPresenter.Web/gospelpresenter-mock.db*
 
 GospelPresenter/.env
+
+# Local MCP server config — contains API keys
+.mcp.json

--- a/GospelPresenter/GospelPresenter.Shared/Components/AppButton.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/AppButton.razor
@@ -1,6 +1,6 @@
 @if (Href is not null)
 {
-    <a href="@Href" target="@Target" title="@Title"
+    <a href="@Href" target="@Target" title="@Title" download="@Download"
        class="@CombinedClass">
         @ChildContent
     </a>
@@ -35,6 +35,7 @@ else
     [Parameter] public string? Class { get; set; }
     [Parameter] public string? Href { get; set; }
     [Parameter] public string? Target { get; set; }
+    [Parameter] public string? Download { get; set; }
     [Parameter] public string? Title { get; set; }
     [Parameter] public string? Type { get; set; }
     [Parameter] public bool AsLabel { get; set; }

--- a/GospelPresenter/GospelPresenter.Shared/Components/Presentations/LivePanel.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Presentations/LivePanel.razor
@@ -5,6 +5,7 @@
 
 @inject RemoteDisplayState RemoteDisplayState
 @inject SharedAppState SharedAppState
+@inject PublicOutputState PublicOutputState
 @inject IJSRuntime JsRuntime
 
 @{
@@ -114,7 +115,7 @@ else
                                 </button>
                             }
 
-                            @foreach (var display in SavedDisplays)
+                            @foreach (var display in Screens)
                             {
                                 var isEnabled = RemoteDisplayState.IsDisplayConnectedToSession(display.DisplayIdentifier, SessionId!);
                                 var isOnline = RemoteDisplayState.IsDisplayOnline(display.DisplayIdentifier);
@@ -147,6 +148,43 @@ else
                                             <ToggleSwitch Value="@isEnabled"/>
                                         </div>
                                     }
+                                </button>
+                            }
+
+                            @foreach (var output in PublicOutputs)
+                            {
+                                var isEnabled = RemoteDisplayState.IsDisplayConnectedToSession(output.DisplayIdentifier, SessionId!);
+                                var viewers = PublicOutputState.GetViewerCount(output.DisplayIdentifier);
+                                var otherPresentation = isEnabled ? null : BroadcastingPresentationName(output.DisplayIdentifier);
+
+                                <button @onclick="() => ToggleOutput(output)"
+                                        class="cursor-pointer flex items-center justify-between gap-2 px-3 py-2 rounded-lg text-sm @(isEnabled ? "text-neutral-600 dark:text-neutral-300 bg-sky-100 dark:bg-sky-900/30 ring-1 ring-sky-500" : "text-neutral-600 dark:text-neutral-300 bg-neutral-100 dark:bg-neutral-700/50")">
+                                    <div class="flex items-center gap-2 min-w-0">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                                             class="size-4 shrink-0 @(isEnabled ? "text-green-500" : "text-neutral-400 dark:text-neutral-500")">
+                                            <path d="M3 3h5v5H3V3Zm1.5 1.5v2h2v-2h-2ZM12 3h5v5h-5V3Zm1.5 1.5v2h2v-2h-2ZM3 12h5v5H3v-5Zm1.5 1.5v2h2v-2h-2ZM12 12h1.5v1.5H12V12Zm3.5 0H17v1.5h-1.5V12ZM12 15.5h1.5V17H12v-1.5Zm3.5 0H17V17h-1.5v-1.5ZM9.5 3H11v1.5H9.5V3Zm0 3H11v1.5H9.5V6Zm0 3H11v1.5H9.5V9ZM3 9.5h1.5V11H3V9.5Zm3.5 0H8V11H6.5V9.5Zm6.5 0h1.5V11H13V9.5Zm3 0H17V11h-1V9.5Z"/>
+                                        </svg>
+                                        <div class="min-w-0 text-left">
+                                            <div class="truncate">@output.Name</div>
+                                            @if (otherPresentation is not null)
+                                            {
+                                                <div class="text-[11px] text-neutral-400 dark:text-neutral-500 truncate">
+                                                    @L["LivePanel.PublicOutputBusy", otherPresentation]
+                                                </div>
+                                            }
+                                        </div>
+                                    </div>
+                                    <div class="flex items-center gap-2 shrink-0">
+                                        @if (isEnabled)
+                                        {
+                                            <span class="text-[11px] @(viewers > 0 ? "text-green-600 dark:text-green-400" : "text-neutral-400 dark:text-neutral-500")">
+                                                @ViewerCountText(viewers)
+                                            </span>
+                                        }
+                                        <div class="pointer-events-none">
+                                            <ToggleSwitch Value="@isEnabled"/>
+                                        </div>
+                                    </div>
                                 </button>
                             }
 
@@ -389,6 +427,33 @@ else
     <RemoteControlInfoDialog PresentationId="@remoteControlPresentationId" PresentationName="@remoteControlPresentationName" OnClose="CloseRemoteControlInfoDialog"/>
 }
 
+@if (outputToTakeOver is not null)
+{
+    <Dialog Class="bg-white dark:bg-neutral-800 max-w-md" OnClose="CancelTakeOver">
+        <div class="p-6 space-y-4">
+            <div class="font-semibold text-lg dark:text-neutral-100">@L["LivePanel.TakeOverTitle"]</div>
+            <p class="text-sm text-neutral-600 dark:text-neutral-300">
+                @if (outputToTakeOverFrom is not null)
+                {
+                    @L["LivePanel.TakeOverMessage", outputToTakeOverFrom, outputToTakeOver.Name]
+                }
+                else
+                {
+                    @L["LivePanel.TakeOverMessageUnknown", outputToTakeOver.Name]
+                }
+            </p>
+            <div class="flex justify-end gap-3">
+                <AppButton Variant="ButtonVariant.Cancel" OnClick="CancelTakeOver">
+                    @L["Common.Cancel"]
+                </AppButton>
+                <AppButton Variant="ButtonVariant.Primary" OnClick="ConfirmTakeOver">
+                    @L["LivePanel.TakeOverConfirm"]
+                </AppButton>
+            </div>
+        </div>
+    </Dialog>
+}
+
 @code {
     [Parameter] public required LiveSlide LiveSlide { get; set; }
     [Parameter] public ActiveOverlay? ActiveOverlay { get; set; }
@@ -418,6 +483,15 @@ else
 
     private HashSet<string> savedDisplayIds => SavedDisplays.Select(d => d.DisplayIdentifier).ToHashSet();
 
+    private List<RemoteDisplay> Screens =>
+        SavedDisplays.Where(d => d.Kind == OutputKind.Screen).ToList();
+
+    private List<RemoteDisplay> PublicOutputs =>
+        SavedDisplays.Where(d => d.Kind == OutputKind.PublicQr).ToList();
+
+    private RemoteDisplay? outputToTakeOver;
+    private string? outputToTakeOverFrom;
+
     private List<ConnectedDisplay> adHocDisplays => SessionId is not null
         ? RemoteDisplayState.GetConnectedDisplays(SessionId)
             .Where(d => !savedDisplayIds.Contains(d.DisplayId)).ToList()
@@ -442,6 +516,7 @@ else
         RemoteDisplayState.DisplayWentOffline += OnDisplayStatusChanged;
         RemoteDisplayState.DisplayPaired += OnDisplayStatusChanged;
         RemoteDisplayState.DisplayUnpaired += OnDisplayStatusChanged;
+        PublicOutputState.ViewerCountChanged += OnDisplayStatusChanged;
     }
 
     protected override async Task OnParametersSetAsync()
@@ -465,6 +540,7 @@ else
         RemoteDisplayState.DisplayWentOffline -= OnDisplayStatusChanged;
         RemoteDisplayState.DisplayPaired -= OnDisplayStatusChanged;
         RemoteDisplayState.DisplayUnpaired -= OnDisplayStatusChanged;
+        PublicOutputState.ViewerCountChanged -= OnDisplayStatusChanged;
         dotNetRef?.Dispose();
         windowCloseRef?.Dispose();
     }
@@ -483,6 +559,69 @@ else
         }
 
         await SaveOutputConfig();
+    }
+
+    private string ViewerCountText(int viewers) => viewers == 1
+        ? L["LivePanel.PublicOutputViewersOne", viewers]
+        : L["LivePanel.PublicOutputViewers", viewers];
+
+    /// <summary>The name of the presentation currently broadcasting to an output, if any.</summary>
+    private string? BroadcastingPresentationName(string identifier)
+    {
+        var sessionId = RemoteDisplayState.GetSessionForDisplay(identifier);
+        if (sessionId is null) return null;
+
+        return SharedAppState.GetActiveSession(sessionId)?.PresentationName;
+    }
+
+    /// <summary>
+    /// Turning a public output on and off. Only one presentation may broadcast to an output at a
+    /// time, and taking one over is confirmed rather than silent: nobody stands next to a
+    /// congregation's phones to notice that the wrong presentation started sending to them.
+    /// </summary>
+    private async Task ToggleOutput(RemoteDisplay output)
+    {
+        if (SessionId is null) return;
+
+        if (RemoteDisplayState.IsDisplayConnectedToSession(output.DisplayIdentifier, SessionId))
+        {
+            RemoteDisplayState.DisableDisplay(output.DisplayIdentifier, SessionId);
+            await SaveOutputConfig();
+            return;
+        }
+
+        if (RemoteDisplayState.IsDisplayConnected(output.DisplayIdentifier))
+        {
+            outputToTakeOver = output;
+            outputToTakeOverFrom = BroadcastingPresentationName(output.DisplayIdentifier);
+            return;
+        }
+
+        await EnableOutput(output);
+    }
+
+    private async Task EnableOutput(RemoteDisplay output)
+    {
+        if (SessionId is null) return;
+
+        RemoteDisplayState.EnableDisplay(output.DisplayIdentifier, SessionId, output.Name);
+        await SaveOutputConfig();
+    }
+
+    private async Task ConfirmTakeOver()
+    {
+        var output = outputToTakeOver;
+        outputToTakeOver = null;
+        outputToTakeOverFrom = null;
+
+        if (output is not null)
+            await EnableOutput(output);
+    }
+
+    private void CancelTakeOver()
+    {
+        outputToTakeOver = null;
+        outputToTakeOverFrom = null;
     }
 
     private async Task OpenLiveWindow()
@@ -560,10 +699,16 @@ else
                 foreach (var displayId in config.EnabledDisplayIds)
                 {
                     var display = SavedDisplays.FirstOrDefault(d => d.DisplayIdentifier == displayId);
-                    // Only restore if the display is not currently bound to any session —
-                    // we never want to steal a display from another active presentation on restore.
-                    if (display is not null && RemoteDisplayState.IsDisplayOnline(displayId)
-                                            && !RemoteDisplayState.IsDisplayConnected(displayId))
+                    if (display is null) continue;
+
+                    // A public output has no device to be online, so only a screen is required
+                    // to report itself present before its binding is restored.
+                    var isAvailable = display.Kind == OutputKind.PublicQr
+                                      || RemoteDisplayState.IsDisplayOnline(displayId);
+
+                    // Only restore if the output is not currently bound to any session —
+                    // we never want to steal it from another active presentation on restore.
+                    if (isAvailable && !RemoteDisplayState.IsDisplayConnected(displayId))
                     {
                         RemoteDisplayState.EnableDisplay(displayId, SessionId!, display.Name);
                     }

--- a/GospelPresenter/GospelPresenter.Shared/Components/Presentations/PublicSlideView.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Presentations/PublicSlideView.razor
@@ -1,0 +1,102 @@
+@using GospelPresenter.Shared.State
+
+@*
+    Renders a live slide for a public output (a visitor's own phone or tablet).
+
+    Unlike LiveSlideView this does NOT use Slide.razor's fixed 1920x1080 canvas. The server
+    renders one HTML fragment that is shared by every viewer of the output, so it cannot know
+    anyone's viewport and cannot compute a scale. Instead the text reflows and CSS sizes it from
+    the viewport, which is also the only way to get readable text on a phone held upright:
+    letterboxing a 16:9 canvas into a portrait screen leaves the text at about 17px.
+
+    The organisation's font family, weight and line height are honoured. Only the absolute pixel
+    size is replaced — by a viewport-relative size that is capped at the configured size, so a
+    desktop viewer sees the slide as designed while a phone gets larger text.
+*@
+
+<div class="absolute inset-0 flex flex-col overflow-hidden">
+    <div class="flex-1 min-w-0 min-h-0 flex items-center justify-center overflow-y-auto">
+        @if (LiveSlide.ItemType == ProjectItemType.Song && LiveSlide.SongPart is not null)
+        {
+            <div class="w-full px-[5vw] py-[4vh] text-center text-white break-words"
+                 style="@ResponsiveTextCss(LiveSlide.SongStyle ?? SlideTextStyle.SongDefault)">
+                @((MarkupString)SongContentHtml)
+            </div>
+        }
+        else if (LiveSlide.ItemType == ProjectItemType.BibleText && LiveSlide.Text is not null)
+        {
+            <div class="w-full px-[5vw] py-[4vh] text-center text-white break-words"
+                 style="@ResponsiveTextCss(LiveSlide.BibleStyle ?? SlideTextStyle.BibleDefault)">
+                @((MarkupString)LiveSlide.Text)
+            </div>
+        }
+        else if (IsImageItem && LiveSlide.ImageUrl is not null)
+        {
+            <img src="@LiveSlide.ImageUrl" alt=""
+                 class="w-full h-full object-contain select-none"/>
+        }
+    </div>
+
+    @if (!string.IsNullOrEmpty(LiveSlide.Credits))
+    {
+        <div class="shrink-0 px-[5vw] pb-[3vh] text-center text-white/40"
+             style="@ResponsiveTextCss(CreditsStyle, MinFontSizePx: 11)">
+            @LiveSlide.Credits
+        </div>
+    }
+
+    @if (Overlay is not null)
+    {
+        <div class="absolute inset-0 pointer-events-none" style="z-index: 50">
+            @if (Overlay.ImageUrl is not null)
+            {
+                <img src="@Overlay.ImageUrl" alt=""
+                     class="absolute inset-0 w-full h-full object-contain"/>
+            }
+            @if (Overlay.Text is not null)
+            {
+                <div class="absolute top-[4vh] left-0 right-0 px-[5vw] text-center text-white/60 whitespace-pre-line"
+                     style="@ResponsiveTextCss(SlideTextStyle.CreditsDefault, MinFontSizePx: 11) text-shadow: 0 1px 4px rgba(0,0,0,0.6);">
+                    @Overlay.Text
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public required LiveSlide LiveSlide { get; set; }
+    [Parameter] public ActiveOverlay? Overlay { get; set; }
+
+    // The slide canvas the configured font sizes are expressed against.
+    private const double BaseSlideWidth = 1920.0;
+    private const double BaseSlideHeight = 1080.0;
+
+    // How much larger the text is relative to its share of the slide width. Without this a
+    // phone in portrait renders the default 85px song text at about 17px, which the audience
+    // this feature exists for cannot read.
+    private const double ViewportBoost = 1.6;
+
+    private bool IsImageItem =>
+        LiveSlide.ItemType is ProjectItemType.Image or ProjectItemType.Slides;
+
+    private string SongContentHtml =>
+        LiveSlide.SongPart?.Content?.Replace("\n", "<br>") ?? "";
+
+    private SlideTextStyle CreditsStyle =>
+        (LiveSlide.ItemType == ProjectItemType.BibleText
+            ? LiveSlide.BibleCreditsStyle
+            : LiveSlide.CreditsStyle) ?? SlideTextStyle.CreditsDefault;
+
+    private static string ResponsiveTextCss(SlideTextStyle style, double MinFontSizePx = 18)
+    {
+        // Width drives readability on a phone; height keeps a long verse from being pushed off
+        // a short window. The height share is not boosted — it mirrors what the slide was
+        // designed to fit on the 1080px canvas, so a wide desktop window looks as intended.
+        var vw = style.FontSize / BaseSlideWidth * 100 * ViewportBoost;
+        var vh = style.FontSize / BaseSlideHeight * 100;
+
+        return string.Create(System.Globalization.CultureInfo.InvariantCulture,
+            $"font-family: {style.FontFamily}; font-weight: {style.FontWeight}; line-height: {style.LineHeight}; font-size: clamp({MinFontSizePx}px, min({vw:0.##}vw, {vh:0.##}vh), {style.FontSize}px);");
+    }
+}

--- a/GospelPresenter/GospelPresenter.Shared/Components/Presentations/PublicWatchPage.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Presentations/PublicWatchPage.razor
@@ -1,0 +1,139 @@
+@using System.Globalization
+
+@*
+    The complete HTML document served at /watch/{code} to a visitor who scanned a public output's
+    QR code.
+
+    This is deliberately NOT a routed Razor page: App.razor mounts the whole router with
+    <Routes @@rendermode="InteractiveServer">, so any routed page would open a Blazor circuit per
+    viewer. A congregation's worth of circuits is both expensive and fragile — a phone that locks
+    its screen kills the socket and Blazor eventually gives up reconnecting. Instead the endpoint
+    renders this document once per request and the page follows the presentation over SSE, which
+    the browser reconnects on its own for free.
+
+    Localised text lives here, in the per-request shell, rather than in the pushed fragments:
+    the fragments are rendered once and shared by every viewer, so they cannot be localised.
+*@
+
+<!DOCTYPE html>
+<html lang="@CultureInfo.CurrentUICulture.TwoLetterISOLanguageName" class="h-dvh bg-black">
+<head>
+    <meta charset="utf-8"/>
+    @* Zooming is intentionally allowed here, unlike in the operator app: a visitor may want to
+       enlarge an imported presentation page, which cannot reflow. *@
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="robots" content="noindex, nofollow"/>
+    <meta name="theme-color" content="#000000"/>
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
+    <title>@Title</title>
+    <link rel="stylesheet" href="/_content/GospelPresenter.Shared/tailwind-output.css"/>
+    <link rel="stylesheet" href="/_content/GospelPresenter.Shared/app.css"/>
+    <link rel="icon" type="image/png" href="/images/favicon-196.png"/>
+</head>
+<body class="h-dvh bg-black overflow-hidden" data-code="@Code">
+
+<div class="relative h-dvh w-screen bg-black">
+    @* The live slide fragment is swapped in here as the presentation advances. *@
+    <div id="slide" class="absolute inset-0" hidden></div>
+
+    @* Shown before the broadcast starts, while it is paused, and after it stops. A visitor's
+       phone must never go completely blank — an all-black page is indistinguishable from a
+       broken one, and they would reload or give up. *@
+    <div id="idle" class="absolute inset-0 flex flex-col items-center justify-center gap-3 px-8 text-center">
+        @* Three pulsing dots rather than a symbol. Anything resembling a signal or wifi glyph
+           reads as an instruction to connect to something — with the organisation's name above
+           it, the screen looked like a network the visitor had to join. *@
+        <div class="flex items-center gap-2">
+            <span class="size-2 rounded-full bg-white/30 animate-pulse"></span>
+            <span class="size-2 rounded-full bg-white/30 animate-pulse" style="animation-delay: 300ms"></span>
+            <span class="size-2 rounded-full bg-white/30 animate-pulse" style="animation-delay: 600ms"></span>
+        </div>
+        @* The output's name, not the organisation's: it tells the visitor which broadcast they
+           are on, which is the question someone who just scanned a code actually has. *@
+        @if (!string.IsNullOrWhiteSpace(IdleHeading))
+        {
+            <div class="text-white/50 text-lg font-medium">@IdleHeading</div>
+        }
+        <div class="text-white/30 text-sm">@L["Watch.Waiting"]</div>
+    </div>
+
+    @* Shown when the output has reached its viewer cap. *@
+    <div id="full" class="absolute inset-0 flex items-center justify-center px-8 text-center" hidden>
+        <div class="text-white/50 text-sm">@L["Watch.Full"]</div>
+    </div>
+</div>
+
+<script>
+    (function () {
+        var code = document.body.dataset.code;
+        var slide = document.getElementById('slide');
+        var idle = document.getElementById('idle');
+        var full = document.getElementById('full');
+
+        function newViewerId() {
+            if (window.crypto && window.crypto.getRandomValues) {
+                var bytes = new Uint8Array(8);
+                window.crypto.getRandomValues(bytes);
+                return Array.from(bytes, function (b) { return b.toString(16).padStart(2, '0'); }).join('');
+            }
+            return String(Date.now()) + Math.random().toString(16).slice(2);
+        }
+
+        // Kept in sessionStorage, not localStorage: it survives a reload so the operator's
+        // viewer count does not double-count, but it disappears with the tab and leaves no
+        // lasting identifier on a visitor's device.
+        var viewerId = sessionStorage.getItem('watch-viewer-id');
+        if (!viewerId) {
+            viewerId = newViewerId();
+            sessionStorage.setItem('watch-viewer-id', viewerId);
+        }
+
+        function showSlide(html) {
+            slide.innerHTML = html;
+            slide.hidden = false;
+            idle.hidden = true;
+        }
+
+        function showIdle() {
+            slide.hidden = true;
+            slide.innerHTML = '';
+            idle.hidden = false;
+        }
+
+        var source = new EventSource('/api/watch/' + encodeURIComponent(code) +
+            '/stream?v=' + encodeURIComponent(viewerId));
+
+        source.addEventListener('slide', function (e) {
+            showSlide(JSON.parse(e.data));
+        });
+
+        source.addEventListener('idle', function () {
+            showIdle();
+        });
+
+        source.addEventListener('full', function () {
+            source.close();
+            slide.hidden = true;
+            idle.hidden = true;
+            full.hidden = false;
+        });
+    })();
+</script>
+
+</body>
+</html>
+
+@code {
+    [Parameter] public required string Code { get; set; }
+    [Parameter] public string? OrganizationName { get; set; }
+    [Parameter] public string? OutputName { get; set; }
+
+    private string? IdleHeading =>
+        string.IsNullOrWhiteSpace(OutputName) ? OrganizationName : OutputName;
+
+    // The browser tab is where the organisation's name belongs: it identifies the page from
+    // outside, in a tab strip or a bookmark, where "Follow along" would say nothing.
+    private string Title =>
+        string.IsNullOrWhiteSpace(OrganizationName) ? "Gospel Presenter" : OrganizationName;
+}

--- a/GospelPresenter/GospelPresenter.Shared/Contexts/PresentationContext.cs
+++ b/GospelPresenter/GospelPresenter.Shared/Contexts/PresentationContext.cs
@@ -147,6 +147,7 @@ public class PresentationContext(DbContextOptions<PresentationContext> options) 
         {
             e.HasIndex(d => d.DisplayIdentifier).IsUnique();
             e.HasIndex(d => d.OrganizationId);
+            e.HasIndex(d => new { d.OrganizationId, d.Kind });
             e.Property(d => d.DisplayIdentifier).HasMaxLength(AppConstraints.NameMaxLength);
             e.Property(d => d.Name).HasMaxLength(AppConstraints.NameMaxLength);
         });

--- a/GospelPresenter/GospelPresenter.Shared/Migrations/20260811133051_AddOutputKindToRemoteDisplays.Designer.cs
+++ b/GospelPresenter/GospelPresenter.Shared/Migrations/20260811133051_AddOutputKindToRemoteDisplays.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GospelPresenter.Shared.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GospelPresenter.Shared.Migrations
 {
     [DbContext(typeof(PresentationContext))]
-    partial class PresentationContextModelSnapshot : ModelSnapshot
+    [Migration("20260811133051_AddOutputKindToRemoteDisplays")]
+    partial class AddOutputKindToRemoteDisplays
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GospelPresenter/GospelPresenter.Shared/Migrations/20260811133051_AddOutputKindToRemoteDisplays.cs
+++ b/GospelPresenter/GospelPresenter.Shared/Migrations/20260811133051_AddOutputKindToRemoteDisplays.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GospelPresenter.Shared.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOutputKindToRemoteDisplays : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Kind",
+                table: "RemoteDisplays",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RemoteDisplays_OrganizationId_Kind",
+                table: "RemoteDisplays",
+                columns: new[] { "OrganizationId", "Kind" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_RemoteDisplays_OrganizationId_Kind",
+                table: "RemoteDisplays");
+
+            migrationBuilder.DropColumn(
+                name: "Kind",
+                table: "RemoteDisplays");
+        }
+    }
+}

--- a/GospelPresenter/GospelPresenter.Shared/Models/RemoteDisplay.cs
+++ b/GospelPresenter/GospelPresenter.Shared/Models/RemoteDisplay.cs
@@ -1,11 +1,23 @@
 namespace GospelPresenter.Shared.Models;
 
+/// <summary>
+/// The kind of output a <see cref="RemoteDisplay"/> represents. A Screen is a single device
+/// (TV, projector) that reports itself online and is paired to a session. A PublicQr output is
+/// a channel that any number of anonymous visitors can watch by scanning a QR code.
+/// </summary>
+public enum OutputKind
+{
+    Screen = 0,
+    PublicQr = 1
+}
+
 public class RemoteDisplay
 {
     public string Id { get; set; } = Guid.NewGuid().ToString();
     public string OrganizationId { get; set; } = "";
     public string DisplayIdentifier { get; set; } = "";
     public string Name { get; set; } = "";
+    public OutputKind Kind { get; set; } = OutputKind.Screen;
     public DateTimeOffset CreatedAt { get; set; }
 
     public Organization Organization { get; set; } = null!;

--- a/GospelPresenter/GospelPresenter.Shared/Pages/Admin/Displays.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Pages/Admin/Displays.razor
@@ -11,15 +11,18 @@
 @inject IRemoteDisplayService RemoteDisplayService
 @inject ActiveOrganizationState OrgState
 @inject RemoteDisplayState RemoteDisplayState
+@inject SharedAppState SharedAppState
+@inject PublicOutputState PublicOutputState
 @inject NavigationManager NavigationManager
 @inject ToastService ToastService
 
 <PageContainer>
+    @* ---------- Screens: a physical device that reports itself online ---------- *@
     <div class="flex items-center justify-between px-5">
         <div class="text-xl font-bold dark:text-neutral-100">@L["Admin.Displays.Title"]</div>
-        @if (displays is not null && displays.Count > 0)
+        @if (Screens.Count > 0)
         {
-            <AppButton Variant="ButtonVariant.Primary" OnClick="ShowCreateDialog" Class="flex items-center gap-1.5">
+            <AppButton Variant="ButtonVariant.Primary" OnClick="() => ShowCreateDialog(OutputKind.Screen)" Class="flex items-center gap-1.5">
                 <PlusSymbol Class="size-4"/>
                 @L["Admin.Displays.Add"]
             </AppButton>
@@ -31,7 +34,7 @@
         {
             <div class="px-7 py-4 text-neutral-400">@L["Common.Loading"]</div>
         }
-        else if (displays.Count == 0)
+        else if (Screens.Count == 0)
         {
             <div class="flex flex-col items-center justify-center text-center px-6 py-12 select-none">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 200 160" class="w-48 h-auto mb-6 text-neutral-300 dark:text-neutral-600">
@@ -47,7 +50,7 @@
                 <p class="text-sm text-neutral-400 dark:text-neutral-500 max-w-xs leading-relaxed mb-4">
                     @L["Admin.Displays.Description"]
                 </p>
-                <AppButton Variant="ButtonVariant.Primary" OnClick="ShowCreateDialog" Class="flex items-center gap-1.5">
+                <AppButton Variant="ButtonVariant.Primary" OnClick="() => ShowCreateDialog(OutputKind.Screen)" Class="flex items-center gap-1.5">
                     <PlusSymbol Class="size-4"/>
                     @L["Admin.Displays.Add"]
                 </AppButton>
@@ -55,14 +58,14 @@
         }
         else
         {
-            @foreach (var display in displays)
+            @foreach (var display in Screens)
             {
                 var isOnline = RemoteDisplayState.IsDisplayOnline(display.DisplayIdentifier);
                 var iconClass = isOnline ? "text-green-500" : "text-neutral-300 dark:text-neutral-600";
                 var statusClass = isOnline ? "text-green-600 dark:text-green-400" : "text-neutral-400 dark:text-neutral-500";
                 var statusText = isOnline ? L["Admin.Displays.Online"] : L["Admin.Displays.Offline"];
 
-                <div class="flex items-center gap-3 px-7 py-3 border-b border-neutral-200 dark:border-neutral-700 last:border-b-0">
+                <div class="flex flex-wrap items-center gap-3 px-7 py-3 border-b border-neutral-200 dark:border-neutral-700 last:border-b-0">
                     <div class="@iconClass">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
                             <path d="M3 5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5Z"/>
@@ -95,6 +98,87 @@
             }
         }
     </div>
+
+    @* ---------- Public outputs: a channel any number of visitors can watch ---------- *@
+    <div class="flex items-center justify-between px-5 pt-6">
+        <div class="text-xl font-bold dark:text-neutral-100">@L["Admin.PublicOutputs.Title"]</div>
+        @if (PublicOutputs.Count > 0)
+        {
+            <AppButton Variant="ButtonVariant.Primary" OnClick="() => ShowCreateDialog(OutputKind.PublicQr)" Class="flex items-center gap-1.5">
+                <PlusSymbol Class="size-4"/>
+                @L["Admin.PublicOutputs.Add"]
+            </AppButton>
+        }
+    </div>
+
+    <div class="bg-neutral-50 dark:bg-neutral-800 dark:text-neutral-100 rounded-xl shadow-sm border-t-[0.5px] border-white dark:border-neutral-700 overflow-hidden">
+        @if (displays is null)
+        {
+            <div class="px-7 py-4 text-neutral-400">@L["Common.Loading"]</div>
+        }
+        else if (PublicOutputs.Count == 0)
+        {
+            <div class="flex flex-col items-center justify-center text-center px-6 py-12 select-none">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 200 160" class="w-48 h-auto mb-6 text-neutral-300 dark:text-neutral-600">
+                    <rect x="55" y="15" width="90" height="90" rx="8" stroke="currentColor" stroke-width="2" class="fill-neutral-100 dark:fill-neutral-800"/>
+                    <rect x="68" y="28" width="20" height="20" rx="3" stroke="currentColor" stroke-width="2" fill="none"/>
+                    <rect x="112" y="28" width="20" height="20" rx="3" stroke="currentColor" stroke-width="2" fill="none"/>
+                    <rect x="68" y="72" width="20" height="20" rx="3" stroke="currentColor" stroke-width="2" fill="none"/>
+                    <rect x="98" y="58" width="8" height="8" rx="1" fill="currentColor" opacity="0.5"/>
+                    <rect x="112" y="72" width="8" height="8" rx="1" fill="currentColor" opacity="0.5"/>
+                    <rect x="124" y="84" width="8" height="8" rx="1" fill="currentColor" opacity="0.5"/>
+                    <rect x="82" y="115" width="36" height="34" rx="5" stroke="currentColor" stroke-width="2" class="fill-neutral-100 dark:fill-neutral-800"/>
+                    <line x1="94" y1="143" x2="106" y2="143" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                </svg>
+                <h2 class="text-lg font-semibold text-neutral-500 dark:text-neutral-400 mb-2">@L["Admin.PublicOutputs.Empty"]</h2>
+                <p class="text-sm text-neutral-400 dark:text-neutral-500 max-w-xs leading-relaxed mb-4">
+                    @L["Admin.PublicOutputs.Description"]
+                </p>
+                <AppButton Variant="ButtonVariant.Primary" OnClick="() => ShowCreateDialog(OutputKind.PublicQr)" Class="flex items-center gap-1.5">
+                    <PlusSymbol Class="size-4"/>
+                    @L["Admin.PublicOutputs.Add"]
+                </AppButton>
+            </div>
+        }
+        else
+        {
+            @foreach (var output in PublicOutputs)
+            {
+                var viewers = PublicOutputState.GetViewerCount(output.DisplayIdentifier);
+                var broadcastingFrom = BroadcastingPresentationName(output.DisplayIdentifier);
+                var isBroadcasting = broadcastingFrom is not null;
+
+                <div class="flex flex-wrap items-center gap-3 px-7 py-3 border-b border-neutral-200 dark:border-neutral-700 last:border-b-0">
+                    <div class="@(isBroadcasting ? "text-green-500" : "text-neutral-300 dark:text-neutral-600")">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
+                            <path d="M3 3h5v5H3V3Zm1.5 1.5v2h2v-2h-2ZM12 3h5v5h-5V3Zm1.5 1.5v2h2v-2h-2ZM3 12h5v5H3v-5Zm1.5 1.5v2h2v-2h-2ZM12 12h1.5v1.5H12V12Zm3.5 0H17v1.5h-1.5V12ZM12 15.5h1.5V17H12v-1.5Zm3.5 0H17V17h-1.5v-1.5ZM9.5 3H11v1.5H9.5V3Zm0 3H11v1.5H9.5V6Zm0 3H11v1.5H9.5V9ZM3 9.5h1.5V11H3V9.5Zm3.5 0H8V11H6.5V9.5Zm6.5 0h1.5V11H13V9.5Zm3 0H17V11h-1V9.5Z"/>
+                        </svg>
+                    </div>
+                    <div class="flex-1 min-w-0">
+                        <div class="font-medium truncate">@output.Name</div>
+                        @if (isBroadcasting)
+                        {
+                            <div class="text-xs text-neutral-400 dark:text-neutral-500 truncate">
+                                @L["Admin.PublicOutputs.BroadcastingFrom", broadcastingFrom!]
+                            </div>
+                        }
+                    </div>
+                    <div class="text-xs @(viewers > 0 ? "text-green-600 dark:text-green-400" : "text-neutral-400 dark:text-neutral-500")">
+                        @ViewerCountText(viewers)
+                    </div>
+                    <AppButton Variant="ButtonVariant.Neutral" OnClick="() => publicOutputToShow = output" Class="text-xs flex items-center gap-1.5">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-3.5">
+                            <path d="M3 3h5v5H3V3Zm1.5 1.5v2h2v-2h-2ZM12 3h5v5h-5V3Zm1.5 1.5v2h2v-2h-2ZM3 12h5v5H3v-5Zm1.5 1.5v2h2v-2h-2ZM12 12h1.5v1.5H12V12Zm3.5 0H17v1.5h-1.5V12ZM12 15.5h1.5V17H12v-1.5Zm3.5 0H17V17h-1.5v-1.5ZM9.5 3H11v1.5H9.5V3Zm0 3H11v1.5H9.5V6Zm0 3H11v1.5H9.5V9ZM3 9.5h1.5V11H3V9.5Zm3.5 0H8V11H6.5V9.5Zm6.5 0h1.5V11H13V9.5Zm3 0H17V11h-1V9.5Z"/>
+                        </svg>
+                        @L["Admin.PublicOutputs.ShowQr"]
+                    </AppButton>
+                    <AppButton Variant="ButtonVariant.Danger" OnClick="() => ConfirmRemoveDisplay(output)" Class="text-xs">
+                        @L["Common.Delete"]
+                    </AppButton>
+                </div>
+            }
+        }
+    </div>
 </PageContainer>
 
 @if (deleteConfirmMessage is not null)
@@ -107,11 +191,14 @@
 
 @if (showCreateDialog)
 {
+    var isPublic = newKind == OutputKind.PublicQr;
     <Dialog Class="bg-white dark:bg-neutral-800 max-w-lg" OnClose="CloseDialog">
         <div class="p-6 space-y-4">
-            <div class="font-semibold text-lg">@L["Admin.Displays.AddTitle"]</div>
+            <div class="font-semibold text-lg">
+                @(isPublic ? L["Admin.PublicOutputs.AddTitle"] : L["Admin.Displays.AddTitle"])
+            </div>
             <p class="text-sm text-neutral-500 dark:text-neutral-400 leading-relaxed">
-                @L["Admin.Displays.AddDescription"]
+                @(isPublic ? L["Admin.PublicOutputs.AddDescription"] : L["Admin.Displays.AddDescription"])
             </p>
             <FloatingInput @ref="nameInput" Id="new-display-name"
                            Label="@L["Admin.Displays.NamePlaceholder"]"
@@ -127,7 +214,7 @@
                            Loading="@adding"
                            OnClick="AddDisplay"
                            title="Ctrl+Enter">
-                    @L["Admin.Displays.Add"]
+                    @(isPublic ? L["Admin.PublicOutputs.Add"] : L["Admin.Displays.Add"])
                 </AppButton>
             </div>
         </div>
@@ -175,22 +262,126 @@
     </Dialog>
 }
 
+@if (publicOutputToShow is not null)
+{
+    var watchUrl = BuildWatchUrl(publicOutputToShow.DisplayIdentifier);
+    <Dialog Class="bg-white dark:bg-neutral-800 max-w-sm" OnClose="() => publicOutputToShow = null" ShowCloseButton="true">
+        <div class="p-6 space-y-5">
+            <div class="font-semibold text-lg pr-10">@publicOutputToShow.Name</div>
+
+            <div class="space-y-2">
+                <div class="flex justify-center">
+                    <QrCode Value="@watchUrl"/>
+                </div>
+                <div class="text-sm text-neutral-500 dark:text-neutral-400 text-center">
+                    @L["Admin.PublicOutputs.ScanQrHint"]
+                </div>
+            </div>
+
+            <div class="flex justify-center">
+                <AppButton Variant="ButtonVariant.Secondary"
+                           Href="@QrCodeImage.ToPngDataUrl(watchUrl)"
+                           Download="@($"qr-{publicOutputToShow.DisplayIdentifier}.png")"
+                           Class="text-xs flex items-center gap-1.5">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                              d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"/>
+                    </svg>
+                    @L["Admin.PublicOutputs.DownloadQr"]
+                </AppButton>
+            </div>
+
+            <div class="space-y-2">
+                <div class="flex items-stretch gap-2">
+                    <input id="show-watch-link" type="text" readonly value="@watchUrl"
+                           class="flex-1 min-w-0 px-3 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-700 text-sm font-mono text-neutral-800 dark:text-neutral-100 border border-neutral-200 dark:border-neutral-600 select-all focus:outline-none focus:ring-2 focus:ring-sky-500"/>
+                    <AppButton Variant="ButtonVariant.Neutral" CopyText="@watchUrl" OnClick="OnCopyUrl"
+                               Title="@L["UserDetail.Copy"]"
+                               Class="!px-3 !py-2 !rounded-lg flex items-center justify-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
+                            <path d="M7 3.5A1.5 1.5 0 0 1 8.5 2h3.879a1.5 1.5 0 0 1 1.06.44l3.122 3.12A1.5 1.5 0 0 1 17 6.622V12.5a1.5 1.5 0 0 1-1.5 1.5h-1v-3.379a3 3 0 0 0-.879-2.121L10.5 5.379A3 3 0 0 0 8.379 4.5H7v-1Z"/>
+                            <path d="M4.5 6A1.5 1.5 0 0 0 3 7.5v9A1.5 1.5 0 0 0 4.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L9.44 6.439A1.5 1.5 0 0 0 8.378 6H4.5Z"/>
+                        </svg>
+                    </AppButton>
+                </div>
+            </div>
+
+            <div class="!mt-8 pt-4 border-t border-neutral-200 dark:border-neutral-700 space-y-3">
+                <p class="text-xs text-neutral-500 dark:text-neutral-400 leading-relaxed">
+                    @L["Admin.PublicOutputs.RegenerateDescription"]
+                </p>
+                <AppButton Variant="ButtonVariant.Danger"
+                           OnClick="() => outputToRegenerate = publicOutputToShow"
+                           Class="text-xs">
+                    @L["Admin.PublicOutputs.Regenerate"]
+                </AppButton>
+            </div>
+        </div>
+    </Dialog>
+}
+
+@if (outputToRegenerate is not null)
+{
+    <Dialog Class="bg-white dark:bg-neutral-800 max-w-md" OnClose="() => outputToRegenerate = null">
+        <div class="p-6 space-y-4">
+            <div class="font-semibold text-lg">@L["Admin.PublicOutputs.Regenerate"]</div>
+            <p class="text-sm text-neutral-600 dark:text-neutral-300">
+                @L["Admin.PublicOutputs.RegenerateWarning", outputToRegenerate.Name]
+            </p>
+            <div class="flex justify-end gap-3">
+                <AppButton Variant="ButtonVariant.Cancel" OnClick="() => outputToRegenerate = null">
+                    @L["Common.Cancel"]
+                </AppButton>
+                <AppButton Variant="ButtonVariant.Danger" Filled
+                           Disabled="regenerating" Loading="regenerating"
+                           OnClick="ExecuteRegenerate">
+                    @L["Admin.PublicOutputs.Regenerate"]
+                </AppButton>
+            </div>
+        </div>
+    </Dialog>
+}
+
 @code {
     private List<RemoteDisplay>? displays;
     private bool showCreateDialog;
+    private OutputKind newKind = OutputKind.Screen;
     private string newName = "";
     private bool adding;
     private FloatingInput? nameInput;
     private bool shouldFocusName;
     private RemoteDisplay? displayToDelete;
     private RemoteDisplay? displayToShow;
+    private RemoteDisplay? publicOutputToShow;
+    private RemoteDisplay? outputToRegenerate;
     private bool isDeleting;
+    private bool regenerating;
+
+    private List<RemoteDisplay> Screens =>
+        displays?.Where(d => d.Kind == OutputKind.Screen).ToList() ?? [];
+
+    private List<RemoteDisplay> PublicOutputs =>
+        displays?.Where(d => d.Kind == OutputKind.PublicQr).ToList() ?? [];
 
     private MarkupString? deleteConfirmMessage => displayToDelete is not null
         ? new MarkupString(L["Admin.Displays.ConfirmDelete", System.Net.WebUtility.HtmlEncode(displayToDelete.Name)])
         : null;
 
     private bool CanAdd => !string.IsNullOrWhiteSpace(newName);
+
+    private string ViewerCountText(int viewers) => viewers == 1
+        ? L["Admin.PublicOutputs.ViewersOne", viewers]
+        : L["Admin.PublicOutputs.Viewers", viewers];
+
+    /// <summary>The name of the presentation currently broadcasting to an output, if any.</summary>
+    private string? BroadcastingPresentationName(string identifier)
+    {
+        var sessionId = RemoteDisplayState.GetSessionForDisplay(identifier);
+        if (sessionId is null) return null;
+
+        var session = SharedAppState.GetActiveSession(sessionId);
+        return session?.PresentationName;
+    }
 
     private string BuildDisplayUrl(string identifier, string name)
     {
@@ -202,6 +393,9 @@
             parts.Add($"name={Uri.EscapeDataString(name.Trim())}");
         return parts.Count > 0 ? $"{baseUrl}?{string.Join("&", parts)}" : baseUrl;
     }
+
+    private string BuildWatchUrl(string identifier) =>
+        $"{NavigationManager.BaseUri.TrimEnd('/')}/watch/{Uri.EscapeDataString(identifier.Trim())}";
 
     private void OnCopyUrl() => ToastService.Show(L["Toast.LinkCopied"]);
 
@@ -219,9 +413,10 @@
         displays = await RemoteDisplayService.GetDisplaysAsync(orgId, caller);
     }
 
-    private void ShowCreateDialog()
+    private void ShowCreateDialog(OutputKind kind)
     {
         newName = "";
+        newKind = kind;
         showCreateDialog = true;
         shouldFocusName = true;
     }
@@ -261,12 +456,17 @@
         var caller = OrgState.ToCallerContext();
         if (orgId is null || caller is null) return;
 
-        var added = await RemoteDisplayService.AddDisplayAsync(orgId, newName.Trim(), caller);
+        var kind = newKind;
+        var added = await RemoteDisplayService.AddDisplayAsync(orgId, newName.Trim(), caller, kind);
         adding = false;
         showCreateDialog = false;
 
         await LoadDisplays();
-        displayToShow = added;
+
+        if (kind == OutputKind.PublicQr)
+            publicOutputToShow = added;
+        else
+            displayToShow = added;
     }
 
     private void ConfirmRemoveDisplay(RemoteDisplay display) => displayToDelete = display;
@@ -282,10 +482,53 @@
         isDeleting = true;
         StateHasChanged();
 
+        var identifier = displayToDelete.DisplayIdentifier;
         await RemoteDisplayService.RemoveDisplayAsync(orgId, displayToDelete.Id, caller);
+        DisconnectOutput(identifier);
+
         isDeleting = false;
         displayToDelete = null;
 
         await LoadDisplays();
+    }
+
+    private async Task ExecuteRegenerate()
+    {
+        if (outputToRegenerate is null || regenerating) return;
+
+        var orgId = OrgState.ActiveOrganizationId;
+        var caller = OrgState.ToCallerContext();
+        if (orgId is null || caller is null) return;
+
+        regenerating = true;
+        StateHasChanged();
+
+        var previousIdentifier = outputToRegenerate.DisplayIdentifier;
+        try
+        {
+            await RemoteDisplayService.RegenerateIdentifierAsync(orgId, outputToRegenerate.Id, caller);
+            DisconnectOutput(previousIdentifier);
+            ToastService.Show(L["Admin.PublicOutputs.RegenerateDone"]);
+        }
+        catch (Exception)
+        {
+            ToastService.Show(L["Common.ErrorOccurred"]);
+        }
+
+        regenerating = false;
+        outputToRegenerate = null;
+        publicOutputToShow = null;
+
+        await LoadDisplays();
+    }
+
+    /// <summary>
+    /// Drops everyone still attached to an output identifier that no longer exists, so a code
+    /// that was deleted or replaced stops working immediately rather than at the next timeout.
+    /// </summary>
+    private void DisconnectOutput(string identifier)
+    {
+        PublicOutputState.RemoveAllViewers(identifier);
+        RemoteDisplayState.DisconnectDisplay(identifier);
     }
 }

--- a/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.resx
+++ b/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.resx
@@ -1346,6 +1346,54 @@
   <data name="Admin.Displays.ConfirmDelete" xml:space="preserve">
     <value>Are you sure you want to delete the display "{0}"?</value>
   </data>
+  <data name="Admin.PublicOutputs.Title" xml:space="preserve">
+    <value>Public outputs</value>
+  </data>
+  <data name="Admin.PublicOutputs.Add" xml:space="preserve">
+    <value>Add public output</value>
+  </data>
+  <data name="Admin.PublicOutputs.AddTitle" xml:space="preserve">
+    <value>New public output</value>
+  </data>
+  <data name="Admin.PublicOutputs.AddDescription" xml:space="preserve">
+    <value>A public output gives you a QR code that visitors can scan to follow the presentation on their own phone. Anyone with the code can watch while a presentation is broadcasting to the output.</value>
+  </data>
+  <data name="Admin.PublicOutputs.Empty" xml:space="preserve">
+    <value>No public outputs</value>
+  </data>
+  <data name="Admin.PublicOutputs.Description" xml:space="preserve">
+    <value>Let visitors follow along on their own device by scanning a QR code.</value>
+  </data>
+  <data name="Admin.PublicOutputs.Viewers" xml:space="preserve">
+    <value>{0} devices</value>
+  </data>
+  <data name="Admin.PublicOutputs.ViewersOne" xml:space="preserve">
+    <value>{0} device</value>
+  </data>
+  <data name="Admin.PublicOutputs.BroadcastingFrom" xml:space="preserve">
+    <value>Broadcasting from {0}</value>
+  </data>
+  <data name="Admin.PublicOutputs.ShowQr" xml:space="preserve">
+    <value>Show QR code</value>
+  </data>
+  <data name="Admin.PublicOutputs.ScanQrHint" xml:space="preserve">
+    <value>Visitors scan this code to follow the presentation on their own device.</value>
+  </data>
+  <data name="Admin.PublicOutputs.DownloadQr" xml:space="preserve">
+    <value>Download as image</value>
+  </data>
+  <data name="Admin.PublicOutputs.Regenerate" xml:space="preserve">
+    <value>New code</value>
+  </data>
+  <data name="Admin.PublicOutputs.RegenerateDescription" xml:space="preserve">
+    <value>If the code has been shared where it does not belong, you can replace it with a new one.</value>
+  </data>
+  <data name="Admin.PublicOutputs.RegenerateWarning" xml:space="preserve">
+    <value>"{0}" gets a brand new code. Every printed sign and saved link stops working, and everyone currently watching is disconnected. This cannot be undone.</value>
+  </data>
+  <data name="Admin.PublicOutputs.RegenerateDone" xml:space="preserve">
+    <value>New code created</value>
+  </data>
   <data name="Admin.Labels.Title" xml:space="preserve">
     <value>Labels</value>
   </data>
@@ -1432,6 +1480,33 @@
   </data>
   <data name="LivePanel.OutputsHint" xml:space="preserve">
     <value>An output is an external screen (TV, projector) that shows the presentation. Add a local view or a separate device via pairing code.</value>
+  </data>
+  <data name="LivePanel.PublicOutputViewers" xml:space="preserve">
+    <value>{0} devices</value>
+  </data>
+  <data name="LivePanel.PublicOutputViewersOne" xml:space="preserve">
+    <value>{0} device</value>
+  </data>
+  <data name="LivePanel.PublicOutputBusy" xml:space="preserve">
+    <value>Broadcasting from {0}</value>
+  </data>
+  <data name="LivePanel.TakeOverTitle" xml:space="preserve">
+    <value>Take over the output?</value>
+  </data>
+  <data name="LivePanel.TakeOverMessage" xml:space="preserve">
+    <value>"{0}" is broadcasting to "{1}". Only one presentation at a time can broadcast to an output. If you take it over, everyone watching follows this presentation instead.</value>
+  </data>
+  <data name="LivePanel.TakeOverMessageUnknown" xml:space="preserve">
+    <value>Another presentation is broadcasting to "{0}". Only one presentation at a time can broadcast to an output. If you take it over, everyone watching follows this presentation instead.</value>
+  </data>
+  <data name="LivePanel.TakeOverConfirm" xml:space="preserve">
+    <value>Take over</value>
+  </data>
+  <data name="Watch.Waiting" xml:space="preserve">
+    <value>Waiting for the broadcast to start</value>
+  </data>
+  <data name="Watch.Full" xml:space="preserve">
+    <value>Too many devices are watching right now. Please try again in a moment.</value>
   </data>
   <data name="LivePanel.RemoteControlHint" xml:space="preserve">
     <value>Turn on to control the presentation from a phone or tablet. A QR code appears when enabled.</value>

--- a/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.sv.resx
+++ b/GospelPresenter/GospelPresenter.Shared/Resources/Localization/SharedResource.sv.resx
@@ -1346,6 +1346,54 @@
   <data name="Admin.Displays.ConfirmDelete" xml:space="preserve">
     <value>Är du säker på att du vill ta bort skärmen "{0}"?</value>
   </data>
+  <data name="Admin.PublicOutputs.Title" xml:space="preserve">
+    <value>Publika utgångar</value>
+  </data>
+  <data name="Admin.PublicOutputs.Add" xml:space="preserve">
+    <value>Lägg till publik utgång</value>
+  </data>
+  <data name="Admin.PublicOutputs.AddTitle" xml:space="preserve">
+    <value>Ny publik utgång</value>
+  </data>
+  <data name="Admin.PublicOutputs.AddDescription" xml:space="preserve">
+    <value>En publik utgång ger dig en QR-kod som besökare kan skanna för att följa presentationen på sin egen telefon. Alla som har koden kan se sändningen när en presentation sänder till utgången.</value>
+  </data>
+  <data name="Admin.PublicOutputs.Empty" xml:space="preserve">
+    <value>Inga publika utgångar</value>
+  </data>
+  <data name="Admin.PublicOutputs.Description" xml:space="preserve">
+    <value>Låt besökare följa med på sin egen enhet genom att skanna en QR-kod.</value>
+  </data>
+  <data name="Admin.PublicOutputs.Viewers" xml:space="preserve">
+    <value>{0} enheter</value>
+  </data>
+  <data name="Admin.PublicOutputs.ViewersOne" xml:space="preserve">
+    <value>{0} enhet</value>
+  </data>
+  <data name="Admin.PublicOutputs.BroadcastingFrom" xml:space="preserve">
+    <value>Sänder från {0}</value>
+  </data>
+  <data name="Admin.PublicOutputs.ShowQr" xml:space="preserve">
+    <value>Visa QR-kod</value>
+  </data>
+  <data name="Admin.PublicOutputs.ScanQrHint" xml:space="preserve">
+    <value>Besökare skannar den här koden för att följa presentationen på sin egen enhet.</value>
+  </data>
+  <data name="Admin.PublicOutputs.DownloadQr" xml:space="preserve">
+    <value>Ladda ner som bild</value>
+  </data>
+  <data name="Admin.PublicOutputs.Regenerate" xml:space="preserve">
+    <value>Ny kod</value>
+  </data>
+  <data name="Admin.PublicOutputs.RegenerateDescription" xml:space="preserve">
+    <value>Om koden har spridits dit den inte hör hemma kan du byta ut den mot en ny.</value>
+  </data>
+  <data name="Admin.PublicOutputs.RegenerateWarning" xml:space="preserve">
+    <value>"{0}" får en helt ny kod. Alla utskrivna skyltar och sparade länkar slutar fungera, och alla som tittar just nu kopplas bort. Detta kan inte ångras.</value>
+  </data>
+  <data name="Admin.PublicOutputs.RegenerateDone" xml:space="preserve">
+    <value>Ny kod skapad</value>
+  </data>
   <data name="Admin.Labels.Title" xml:space="preserve">
     <value>Etiketter</value>
   </data>
@@ -1432,6 +1480,33 @@
   </data>
   <data name="LivePanel.OutputsHint" xml:space="preserve">
     <value>En utgång är en extern skärm (TV, projektor) som visar presentationen. Lägg till en lokal vy eller en separat enhet via parkod.</value>
+  </data>
+  <data name="LivePanel.PublicOutputViewers" xml:space="preserve">
+    <value>{0} enheter</value>
+  </data>
+  <data name="LivePanel.PublicOutputViewersOne" xml:space="preserve">
+    <value>{0} enhet</value>
+  </data>
+  <data name="LivePanel.PublicOutputBusy" xml:space="preserve">
+    <value>Sänder från {0}</value>
+  </data>
+  <data name="LivePanel.TakeOverTitle" xml:space="preserve">
+    <value>Ta över utgången?</value>
+  </data>
+  <data name="LivePanel.TakeOverMessage" xml:space="preserve">
+    <value>"{0}" sänder till "{1}". Bara en presentation åt gången kan sända till en utgång. Om du tar över följer alla som tittar den här presentationen i stället.</value>
+  </data>
+  <data name="LivePanel.TakeOverMessageUnknown" xml:space="preserve">
+    <value>En annan presentation sänder till "{0}". Bara en presentation åt gången kan sända till en utgång. Om du tar över följer alla som tittar den här presentationen i stället.</value>
+  </data>
+  <data name="LivePanel.TakeOverConfirm" xml:space="preserve">
+    <value>Ta över</value>
+  </data>
+  <data name="Watch.Waiting" xml:space="preserve">
+    <value>Väntar på att sändningen ska börja</value>
+  </data>
+  <data name="Watch.Full" xml:space="preserve">
+    <value>För många enheter tittar just nu. Försök igen om en liten stund.</value>
   </data>
   <data name="LivePanel.RemoteControlHint" xml:space="preserve">
     <value>Slå på för att styra presentationen från en mobil eller surfplatta. En QR-kod visas när du slår på.</value>

--- a/GospelPresenter/GospelPresenter.Shared/Services/ImageUrlHelper.cs
+++ b/GospelPresenter/GospelPresenter.Shared/Services/ImageUrlHelper.cs
@@ -16,6 +16,23 @@ public static class ImageUrlHelper
     public static string LiveOverlayImageUrl(string sessionId, string overlayId)
         => $"/api/live-images/{sessionId}/overlay/{overlayId}/image";
 
+    // Public output (watch) URLs (unauthenticated, keyed on the output code rather than the
+    // session id, so the operator's session id is never published to the visitors' devices —
+    // and so that switching the output off stops the images immediately).
+    public static string LiveImagePrefix(string sessionId)
+        => $"/api/live-images/{sessionId}/";
+
+    public static string WatchImagePrefix(string outputCode)
+        => $"/api/watch/{outputCode}/image/";
+
+    /// <summary>
+    /// Rewrites a live image URL so it is served through a public output's proxy instead.
+    /// The live URL layout is fixed, so replacing the prefix covers org images, overlays
+    /// and imported presentation pages alike.
+    /// </summary>
+    public static string? ToWatchUrl(string? liveUrl, string sessionId, string outputCode)
+        => liveUrl?.Replace(LiveImagePrefix(sessionId), WatchImagePrefix(outputCode), StringComparison.Ordinal);
+
     // S3 object keys (used by services and API endpoints)
     public static string OrgImageKey(string organizationId, string imageId, string variant)
         => $"org/{organizationId}/images/{imageId}/{variant}";

--- a/GospelPresenter/GospelPresenter.Shared/Services/QrCodeImage.cs
+++ b/GospelPresenter/GospelPresenter.Shared/Services/QrCodeImage.cs
@@ -1,0 +1,21 @@
+using QRCoder;
+
+namespace GospelPresenter.Shared.Services;
+
+public static class QrCodeImage
+{
+    /// <summary>
+    /// Renders a QR code as a PNG data URL, big enough to print on a sign.
+    ///
+    /// Offered as a download so an operator can put the code up in the entrance and can also add
+    /// it to a presentation as an ordinary image or overlay — which is how the code gets projected
+    /// before a service without any of this touching the live rendering path.
+    /// </summary>
+    public static string ToPngDataUrl(string value, int pixelsPerModule = 24)
+    {
+        using var generator = new QRCodeGenerator();
+        using var data = generator.CreateQrCode(value, QRCodeGenerator.ECCLevel.M);
+        var png = new PngByteQRCode(data);
+        return "data:image/png;base64," + Convert.ToBase64String(png.GetGraphic(pixelsPerModule));
+    }
+}

--- a/GospelPresenter/GospelPresenter.Shared/Services/RemoteDisplayService.cs
+++ b/GospelPresenter/GospelPresenter.Shared/Services/RemoteDisplayService.cs
@@ -8,9 +8,25 @@ namespace GospelPresenter.Shared.Services;
 public interface IRemoteDisplayService
 {
     Task<List<RemoteDisplay>> GetDisplaysAsync(string organizationId, CallerContext caller);
-    Task<RemoteDisplay> AddDisplayAsync(string organizationId, string name, CallerContext caller);
+
+    Task<RemoteDisplay> AddDisplayAsync(string organizationId, string name, CallerContext caller,
+        OutputKind kind = OutputKind.Screen);
+
     Task RemoveDisplayAsync(string organizationId, string id, CallerContext caller);
     Task UpdateDisplayAsync(string organizationId, string id, string name, CallerContext caller);
+
+    /// <summary>
+    /// Replaces the public identifier of an output. Used when a public QR code has been shared
+    /// somewhere it does not belong — the only remedy available, since printed signs cannot be
+    /// recalled. Returns the new identifier, or null if the output does not exist.
+    /// </summary>
+    Task<string?> RegenerateIdentifierAsync(string organizationId, string id, CallerContext caller);
+
+    /// <summary>
+    /// Resolves a public output by its identifier without any permission check. Used by the
+    /// anonymous watch endpoints, which only ever get the identifier from the visitor's URL.
+    /// </summary>
+    Task<RemoteDisplay?> FindPublicOutputAsync(string displayIdentifier);
 }
 
 public class RemoteDisplayService(
@@ -35,7 +51,8 @@ public class RemoteDisplayService(
             .ToListAsync();
     }
 
-    public async Task<RemoteDisplay> AddDisplayAsync(string organizationId, string name, CallerContext caller)
+    public async Task<RemoteDisplay> AddDisplayAsync(string organizationId, string name, CallerContext caller,
+        OutputKind kind = OutputKind.Screen)
     {
         caller.RequirePermission(Permission.ManageRemoteDisplays);
         caller.RequireOrganizationAccess(organizationId);
@@ -49,6 +66,7 @@ public class RemoteDisplayService(
                 OrganizationId = organizationId,
                 DisplayIdentifier = GenerateDisplayId(),
                 Name = name,
+                Kind = kind,
                 CreatedAt = DateTimeOffset.UtcNow
             };
 
@@ -98,4 +116,41 @@ public class RemoteDisplayService(
             .ExecuteUpdateAsync(s => s.SetProperty(d => d.Name, name));
     }
 
+    public async Task<string?> RegenerateIdentifierAsync(string organizationId, string id, CallerContext caller)
+    {
+        caller.RequirePermission(Permission.ManageRemoteDisplays);
+        caller.RequireOrganizationAccess(organizationId);
+
+        await using var context = await dbContextFactory.CreateDbContextAsync();
+
+        var display = await context.RemoteDisplays
+            .FirstOrDefaultAsync(d => d.Id == id && d.OrganizationId == organizationId);
+        if (display is null)
+            return null;
+
+        for (var attempt = 0; attempt < MaxIdRetries; attempt++)
+        {
+            display.DisplayIdentifier = GenerateDisplayId();
+            try
+            {
+                await context.SaveChangesAsync();
+                return display.DisplayIdentifier;
+            }
+            catch (DbUpdateException) when (attempt < MaxIdRetries - 1)
+            {
+                // Unique-index collision on DisplayIdentifier — try another identifier.
+            }
+        }
+
+        throw new InvalidOperationException("Failed to generate a unique display ID after multiple attempts.");
+    }
+
+    public async Task<RemoteDisplay?> FindPublicOutputAsync(string displayIdentifier)
+    {
+        await using var context = await dbContextFactory.CreateDbContextAsync();
+        return await context.RemoteDisplays
+            .Include(d => d.Organization)
+            .FirstOrDefaultAsync(d =>
+                d.DisplayIdentifier == displayIdentifier && d.Kind == OutputKind.PublicQr);
+    }
 }

--- a/GospelPresenter/GospelPresenter.Shared/SharedServicesSetup.cs
+++ b/GospelPresenter/GospelPresenter.Shared/SharedServicesSetup.cs
@@ -12,6 +12,7 @@ public static class SharedServicesSetup
     public static void AddSharedGospelPresenterServices(this IServiceCollection services, IConfiguration? configuration = null)
     {
         var timeoutMinutes = configuration?.GetValue("Settings:SessionTimeoutMinutes", 240) ?? 240;
+        var maxPublicViewers = configuration?.GetValue("Settings:PublicOutputMaxViewers", 500) ?? 500;
 
         services.AddLocalization(options => options.ResourcesPath = "Resources");
         services.AddScoped<ToastService>();
@@ -21,6 +22,8 @@ public static class SharedServicesSetup
             TimeSpan.FromMinutes(timeoutMinutes),
             sp.GetRequiredService<ILogger<SharedAppState>>()));
         services.AddSingleton<RemoteDisplayState>();
+        services.AddSingleton<PublicOutputState>(_ => new PublicOutputState(maxPublicViewers));
+        services.AddSingleton<PublicOutputBroadcaster>();
         services.AddScoped<IRemoteDisplayService, RemoteDisplayService>();
         services.AddScoped<ISongPartLabelService, SongPartLabelService>();
         services.AddSingleton<IImageService, ImageService>();

--- a/GospelPresenter/GospelPresenter.Shared/State/PublicOutputBroadcaster.cs
+++ b/GospelPresenter/GospelPresenter.Shared/State/PublicOutputBroadcaster.cs
@@ -1,0 +1,191 @@
+using System.ComponentModel;
+using GospelPresenter.Shared.Components.Presentations;
+using GospelPresenter.Shared.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace GospelPresenter.Shared.State;
+
+/// <summary>
+/// Turns live presentation state into HTML for the public outputs that have viewers.
+///
+/// The slide is rendered once per output per change and the same string is pushed to every
+/// viewer, so the cost of a bigger audience is one open response per person rather than a
+/// render and a diff per person.
+/// </summary>
+public class PublicOutputBroadcaster : IDisposable
+{
+    private readonly IServiceProvider services;
+    private readonly ILoggerFactory loggerFactory;
+    private readonly SharedAppState sharedAppState;
+    private readonly RemoteDisplayState remoteDisplayState;
+    private readonly PublicOutputState publicOutputState;
+    private readonly ILogger<PublicOutputBroadcaster> logger;
+
+    public PublicOutputBroadcaster(
+        IServiceProvider services,
+        ILoggerFactory loggerFactory,
+        SharedAppState sharedAppState,
+        RemoteDisplayState remoteDisplayState,
+        PublicOutputState publicOutputState)
+    {
+        this.services = services;
+        this.loggerFactory = loggerFactory;
+        this.sharedAppState = sharedAppState;
+        this.remoteDisplayState = remoteDisplayState;
+        this.publicOutputState = publicOutputState;
+        logger = loggerFactory.CreateLogger<PublicOutputBroadcaster>();
+
+        // SharedAppState raises PropertyChanged with the session id as the property name, and
+        // does so for slide changes, black screen, overlays, activation and deactivation alike.
+        sharedAppState.PropertyChanged += OnSharedAppStateChanged;
+        remoteDisplayState.DisplayPaired += OnOutputBindingChanged;
+        remoteDisplayState.DisplayUnpaired += OnOutputBindingChanged;
+    }
+
+    /// <summary>
+    /// The session currently broadcasting to an output, or null if nothing is.
+    ///
+    /// Both conditions matter: an output that has been switched off has no bound session, and a
+    /// bound session that is not presenting has nothing to send. This is the single gate for
+    /// everything a visitor may see — the slide fragments and the proxied images alike.
+    /// </summary>
+    public string? GetBroadcastingSessionId(string outputCode)
+    {
+        var sessionId = remoteDisplayState.GetSessionForDisplay(outputCode);
+        if (sessionId is null || !sharedAppState.IsPresentationActive(sessionId))
+            return null;
+
+        return sessionId;
+    }
+
+    /// <summary>
+    /// The organisation whose images an output may serve, or null if it may serve none.
+    /// Organisation isolation itself falls out of the S3 key structure, exactly as it does for
+    /// the live-image endpoints.
+    /// </summary>
+    public string? GetBroadcastingOrganizationId(string outputCode)
+    {
+        var sessionId = GetBroadcastingSessionId(outputCode);
+        return sessionId is null ? null : sharedAppState.GetSessionOrganizationId(sessionId);
+    }
+
+    /// <summary>
+    /// Builds the event describing what an output should be showing right now. Used both when a
+    /// viewer connects and whenever the live state changes.
+    /// </summary>
+    public async Task<PublicOutputEvent> GetCurrentEventAsync(string outputCode)
+    {
+        var sessionId = GetBroadcastingSessionId(outputCode);
+        if (sessionId is null)
+            return PublicOutputEvent.Idle;
+
+        var slide = sharedAppState.GetLiveSlide(sessionId);
+        if (slide.Status == LiveSlideStatus.ShowingBlackScreen)
+            return PublicOutputEvent.Idle;
+
+        if (slide.ItemType is null)
+            return PublicOutputEvent.Idle;
+
+        var overlay = sharedAppState.GetActiveOverlay(sessionId);
+
+        try
+        {
+            var html = await RenderSlideAsync(slide, overlay, sessionId, outputCode);
+            return PublicOutputEvent.Slide(html);
+        }
+        catch (Exception ex)
+        {
+            // A failed render must not take the visitors' pages down — fall back to the
+            // waiting screen, which is a legible state rather than a blank one.
+            logger.LogError(ex, "Failed to render slide for public output {OutputCode}", outputCode);
+            return PublicOutputEvent.Idle;
+        }
+    }
+
+    private async Task<string> RenderSlideAsync(
+        LiveSlide slide, ActiveOverlay? overlay, string sessionId, string outputCode)
+    {
+        // The visitors must never receive the operator's session id, so image URLs are rewritten
+        // to go through the output's own proxy before the fragment is rendered.
+        var proxiedSlide = slide with
+        {
+            ImageUrl = ImageUrlHelper.ToWatchUrl(slide.ImageUrl, sessionId, outputCode)
+        };
+
+        var proxiedOverlay = overlay is null
+            ? null
+            : overlay with
+            {
+                ImageUrl = ImageUrlHelper.ToWatchUrl(overlay.ImageUrl, sessionId, outputCode)
+            };
+
+        var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            [nameof(PublicSlideView.LiveSlide)] = proxiedSlide,
+            [nameof(PublicSlideView.Overlay)] = proxiedOverlay
+        });
+
+        // A scope of its own: the render components take everything as parameters, but every
+        // component in this assembly inherits an IStringLocalizer injection from _Imports.razor.
+        await using var scope = services.CreateAsyncScope();
+        await using var renderer = new HtmlRenderer(scope.ServiceProvider, loggerFactory);
+
+        return await renderer.Dispatcher.InvokeAsync(async () =>
+        {
+            var output = await renderer.RenderComponentAsync<PublicSlideView>(parameters);
+            return output.ToHtmlString();
+        });
+    }
+
+    private void OnSharedAppStateChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        var sessionId = e.PropertyName;
+        if (string.IsNullOrEmpty(sessionId))
+            return;
+
+        // Only outputs that actually have viewers are worth rendering for. That set is small,
+        // so the reverse lookup from session to output needs no bookkeeping of its own — and it
+        // keeps the knowledge of which displays are public out of the state layer.
+        foreach (var outputCode in publicOutputState.GetCodesWithViewers())
+        {
+            if (remoteDisplayState.GetSessionForDisplay(outputCode) == sessionId)
+                RefreshOutput(outputCode);
+        }
+    }
+
+    private void OnOutputBindingChanged(string displayId)
+    {
+        if (publicOutputState.GetViewerCount(displayId) > 0)
+            RefreshOutput(displayId);
+    }
+
+    /// <summary>
+    /// Renders and publishes the current state of an output. Fire-and-forget on purpose: the
+    /// callers are synchronous state-change notifications that must not wait for a render.
+    /// </summary>
+    public void RefreshOutput(string outputCode)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var evt = await GetCurrentEventAsync(outputCode);
+                publicOutputState.Publish(outputCode, evt);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to publish state for public output {OutputCode}", outputCode);
+            }
+        });
+    }
+
+    public void Dispose()
+    {
+        sharedAppState.PropertyChanged -= OnSharedAppStateChanged;
+        remoteDisplayState.DisplayPaired -= OnOutputBindingChanged;
+        remoteDisplayState.DisplayUnpaired -= OnOutputBindingChanged;
+    }
+}

--- a/GospelPresenter/GospelPresenter.Shared/State/PublicOutputState.cs
+++ b/GospelPresenter/GospelPresenter.Shared/State/PublicOutputState.cs
@@ -1,0 +1,189 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+
+namespace GospelPresenter.Shared.State;
+
+/// <summary>
+/// What a public output pushes to its viewers. Slide carries a rendered HTML fragment;
+/// Idle means there is nothing to show (no presentation broadcasting, or a black screen).
+/// </summary>
+public enum PublicOutputEventType
+{
+    Slide,
+    Idle
+}
+
+public record PublicOutputEvent(PublicOutputEventType Type, string? Html = null)
+{
+    public static readonly PublicOutputEvent Idle = new(PublicOutputEventType.Idle);
+
+    public static PublicOutputEvent Slide(string html) => new(PublicOutputEventType.Slide, html);
+}
+
+/// <summary>
+/// Tracks the anonymous visitors currently watching each public output and carries events to them.
+///
+/// A viewer is identified by an id the browser keeps in sessionStorage, so an EventSource
+/// reconnect or a page reload replaces the existing entry instead of counting twice, and the
+/// viewer disappears when the tab is closed.
+/// </summary>
+public class PublicOutputState
+{
+    private static readonly TimeSpan ViewerTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan CountNotifyInterval = TimeSpan.FromSeconds(2);
+
+    private sealed class Viewer
+    {
+        public required Channel<PublicOutputEvent> Events { get; init; }
+        public DateTime LastSeen { get; set; }
+    }
+
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, Viewer>> viewers = new();
+    private readonly ConcurrentDictionary<string, DateTime> lastNotified = new();
+    private readonly ConcurrentDictionary<string, Timer> pendingNotifications = new();
+    private readonly int maxViewersPerOutput;
+
+    public PublicOutputState(int maxViewersPerOutput = 500)
+    {
+        this.maxViewersPerOutput = maxViewersPerOutput;
+    }
+
+    /// <summary>Raised with the output code when its viewer count has changed. Throttled.</summary>
+    public event Action<string>? ViewerCountChanged;
+
+    public int MaxViewersPerOutput => maxViewersPerOutput;
+
+    /// <summary>
+    /// Registers a viewer and returns the channel to read events from. Returns false when the
+    /// output is at its viewer cap — a safety valve for the server, not a policy for operators.
+    /// A viewer id that is already registered always succeeds, so reconnects are never rejected.
+    /// </summary>
+    public bool TryAddViewer(string code, string viewerId, out ChannelReader<PublicOutputEvent> reader)
+    {
+        CleanupStaleViewers();
+
+        var outputViewers = viewers.GetOrAdd(code, _ => new ConcurrentDictionary<string, Viewer>());
+
+        var isExisting = outputViewers.ContainsKey(viewerId);
+        if (!isExisting && outputViewers.Count >= maxViewersPerOutput)
+        {
+            reader = Channel.CreateBounded<PublicOutputEvent>(1).Reader;
+            return false;
+        }
+
+        // Capacity 1 with DropOldest: only the latest state matters, so a viewer whose
+        // connection stalls gets the current slide rather than a backlog of stale ones.
+        var viewer = new Viewer
+        {
+            Events = Channel.CreateBounded<PublicOutputEvent>(
+                new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropOldest }),
+            LastSeen = DateTime.UtcNow
+        };
+
+        if (outputViewers.TryGetValue(viewerId, out var previous))
+            previous.Events.Writer.TryComplete();
+
+        outputViewers[viewerId] = viewer;
+        reader = viewer.Events.Reader;
+
+        if (!isExisting)
+            NotifyViewerCountChanged(code);
+
+        return true;
+    }
+
+    public void RemoveViewer(string code, string viewerId)
+    {
+        if (!viewers.TryGetValue(code, out var outputViewers))
+            return;
+
+        if (!outputViewers.TryRemove(viewerId, out var viewer))
+            return;
+
+        viewer.Events.Writer.TryComplete();
+
+        if (outputViewers.IsEmpty)
+            viewers.TryRemove(code, out _);
+
+        NotifyViewerCountChanged(code);
+    }
+
+    /// <summary>Removes every viewer of an output, e.g. when its identifier is regenerated.</summary>
+    public void RemoveAllViewers(string code)
+    {
+        if (!viewers.TryRemove(code, out var outputViewers))
+            return;
+
+        foreach (var viewer in outputViewers.Values)
+            viewer.Events.Writer.TryComplete();
+
+        NotifyViewerCountChanged(code);
+    }
+
+    public int GetViewerCount(string code) =>
+        viewers.TryGetValue(code, out var outputViewers) ? outputViewers.Count : 0;
+
+    /// <summary>The output codes that currently have at least one viewer.</summary>
+    public IReadOnlyCollection<string> GetCodesWithViewers() => viewers.Keys.ToList();
+
+    public void Publish(string code, PublicOutputEvent evt)
+    {
+        if (!viewers.TryGetValue(code, out var outputViewers))
+            return;
+
+        foreach (var viewer in outputViewers.Values)
+            viewer.Events.Writer.TryWrite(evt);
+    }
+
+    /// <summary>Records that a viewer's connection is still writable, from the periodic ping.</summary>
+    public void TouchViewer(string code, string viewerId)
+    {
+        if (viewers.TryGetValue(code, out var outputViewers) &&
+            outputViewers.TryGetValue(viewerId, out var viewer))
+        {
+            viewer.LastSeen = DateTime.UtcNow;
+        }
+    }
+
+    public void CleanupStaleViewers()
+    {
+        var now = DateTime.UtcNow;
+        foreach (var (code, outputViewers) in viewers)
+        {
+            foreach (var (viewerId, viewer) in outputViewers)
+            {
+                if (now - viewer.LastSeen > ViewerTimeout)
+                    RemoveViewer(code, viewerId);
+            }
+        }
+    }
+
+    private void NotifyViewerCountChanged(string code)
+    {
+        var now = DateTime.UtcNow;
+        var elapsed = now - lastNotified.GetValueOrDefault(code);
+
+        if (elapsed >= CountNotifyInterval)
+        {
+            lastNotified[code] = now;
+            ViewerCountChanged?.Invoke(code);
+            return;
+        }
+
+        // Notified recently. Schedule a single trailing signal so the final count is never lost,
+        // without emitting one signal per viewer while a congregation scans the code at once.
+        if (pendingNotifications.ContainsKey(code))
+            return;
+
+        var timer = new Timer(_ =>
+        {
+            if (pendingNotifications.TryRemove(code, out var pending))
+                pending.Dispose();
+            lastNotified[code] = DateTime.UtcNow;
+            ViewerCountChanged?.Invoke(code);
+        }, null, CountNotifyInterval - elapsed, Timeout.InfiniteTimeSpan);
+
+        if (!pendingNotifications.TryAdd(code, timer))
+            timer.Dispose();
+    }
+}

--- a/GospelPresenter/GospelPresenter.UnitTests/Services/RemoteDisplayServiceTests.cs
+++ b/GospelPresenter/GospelPresenter.UnitTests/Services/RemoteDisplayServiceTests.cs
@@ -1,0 +1,210 @@
+using GospelPresenter.Shared.Contexts;
+using GospelPresenter.Shared.Models;
+using GospelPresenter.Shared.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace GospelPresenter.UnitTests.Services;
+
+public class RemoteDisplayServiceTests : IDisposable
+{
+    private const string OrgName = "Test Org";
+    private const string OtherOrgName = "Other Org";
+    private const string ScreenName = "Sanctuary projector";
+    private const string PublicOutputName = "Follow along";
+
+    private readonly SqliteConnection connection;
+    private readonly IDbContextFactory<PresentationContext> factory;
+    private readonly RemoteDisplayService service;
+    private readonly Organization org;
+    private readonly CallerContext caller;
+
+    public RemoteDisplayServiceTests()
+    {
+        connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<PresentationContext>()
+            .UseSqlite(connection)
+            .Options;
+        factory = new TestDbContextFactory(options);
+        service = new RemoteDisplayService(factory);
+
+        using var context = factory.CreateDbContext();
+        context.Database.EnsureCreated();
+
+        org = new Organization { Name = OrgName };
+        context.Organizations.Add(org);
+        context.SaveChanges();
+
+        caller = new CallerContext("user-1", UserRole.Admin, org.Id);
+    }
+
+    public void Dispose()
+    {
+        connection.Dispose();
+    }
+
+    [Fact]
+    public async Task AddDisplayAsync_ByDefault_CreatesAScreen()
+    {
+        var added = await service.AddDisplayAsync(org.Id, ScreenName, caller);
+
+        added.Kind.ShouldBe(OutputKind.Screen);
+    }
+
+    [Fact]
+    public async Task AddDisplayAsync_WithPublicQrKind_CreatesAPublicOutput()
+    {
+        var added = await service.AddDisplayAsync(org.Id, PublicOutputName, caller, OutputKind.PublicQr);
+
+        added.Kind.ShouldBe(OutputKind.PublicQr);
+        added.Name.ShouldBe(PublicOutputName);
+    }
+
+    [Fact]
+    public async Task AddDisplayAsync_GeneratesASevenCharacterIdentifier()
+    {
+        var added = await service.AddDisplayAsync(org.Id, PublicOutputName, caller, OutputKind.PublicQr);
+
+        added.DisplayIdentifier.Length.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task GetDisplaysAsync_ReturnsBothKinds()
+    {
+        await service.AddDisplayAsync(org.Id, ScreenName, caller);
+        await service.AddDisplayAsync(org.Id, PublicOutputName, caller, OutputKind.PublicQr);
+
+        var displays = await service.GetDisplaysAsync(org.Id, caller);
+
+        displays.Count(d => d.Kind == OutputKind.Screen).ShouldBe(1);
+        displays.Count(d => d.Kind == OutputKind.PublicQr).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task FindPublicOutputAsync_FindsAPublicOutputByItsIdentifier()
+    {
+        var added = await service.AddDisplayAsync(org.Id, PublicOutputName, caller, OutputKind.PublicQr);
+
+        var found = await service.FindPublicOutputAsync(added.DisplayIdentifier);
+
+        found.ShouldNotBeNull();
+        found.Id.ShouldBe(added.Id);
+        found.Organization.Name.ShouldBe(OrgName);
+    }
+
+    [Fact]
+    public async Task FindPublicOutputAsync_DoesNotFindAScreen()
+    {
+        var screen = await service.AddDisplayAsync(org.Id, ScreenName, caller);
+
+        // A screen's identifier must not open the public watch page: it was never meant to be
+        // handed out to visitors.
+        var found = await service.FindPublicOutputAsync(screen.DisplayIdentifier);
+
+        found.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task FindPublicOutputAsync_WithUnknownIdentifier_ReturnsNull()
+    {
+        var found = await service.FindPublicOutputAsync("nosuch1");
+
+        found.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RegenerateIdentifierAsync_ReplacesTheIdentifier()
+    {
+        var added = await service.AddDisplayAsync(org.Id, PublicOutputName, caller, OutputKind.PublicQr);
+        var original = added.DisplayIdentifier;
+
+        var replacement = await service.RegenerateIdentifierAsync(org.Id, added.Id, caller);
+
+        replacement.ShouldNotBeNull();
+        replacement.ShouldNotBe(original);
+        replacement.Length.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task RegenerateIdentifierAsync_MakesTheOldIdentifierStopWorking()
+    {
+        var added = await service.AddDisplayAsync(org.Id, PublicOutputName, caller, OutputKind.PublicQr);
+        var original = added.DisplayIdentifier;
+
+        await service.RegenerateIdentifierAsync(org.Id, added.Id, caller);
+
+        (await service.FindPublicOutputAsync(original)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RegenerateIdentifierAsync_KeepsTheName()
+    {
+        var added = await service.AddDisplayAsync(org.Id, PublicOutputName, caller, OutputKind.PublicQr);
+
+        var replacement = await service.RegenerateIdentifierAsync(org.Id, added.Id, caller);
+
+        var found = await service.FindPublicOutputAsync(replacement!);
+        found!.Name.ShouldBe(PublicOutputName);
+    }
+
+    [Fact]
+    public async Task RegenerateIdentifierAsync_ForUnknownOutput_ReturnsNull()
+    {
+        var replacement = await service.RegenerateIdentifierAsync(org.Id, "no-such-id", caller);
+
+        replacement.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RegenerateIdentifierAsync_WhenCallerBelongsToAnotherOrganization_Throws()
+    {
+        var added = await service.AddDisplayAsync(org.Id, PublicOutputName, caller, OutputKind.PublicQr);
+        var otherCaller = await CreateCallerInOtherOrganizationAsync();
+
+        await Should.ThrowAsync<UnauthorizedAccessException>(() =>
+            service.RegenerateIdentifierAsync(org.Id, added.Id, otherCaller));
+    }
+
+    [Fact]
+    public async Task RegenerateIdentifierAsync_ForAnOutputInAnotherOrganization_ReturnsNull()
+    {
+        var added = await service.AddDisplayAsync(org.Id, PublicOutputName, caller, OutputKind.PublicQr);
+        var otherCaller = await CreateCallerInOtherOrganizationAsync();
+
+        // Scoping to the caller's own organisation means another organisation's output is simply
+        // not found, so its code can never be replaced from outside.
+        var replacement = await service.RegenerateIdentifierAsync(
+            otherCaller.OrganizationId!, added.Id, otherCaller);
+
+        replacement.ShouldBeNull();
+        (await service.FindPublicOutputAsync(added.DisplayIdentifier)).ShouldNotBeNull();
+    }
+
+    private async Task<CallerContext> CreateCallerInOtherOrganizationAsync()
+    {
+        await using var context = await factory.CreateDbContextAsync();
+        var otherOrg = new Organization { Name = OtherOrgName };
+        context.Organizations.Add(otherOrg);
+        await context.SaveChangesAsync();
+
+        return new CallerContext("user-2", UserRole.Admin, otherOrg.Id);
+    }
+
+    [Fact]
+    public async Task AddDisplayAsync_WithoutPermission_Throws()
+    {
+        var viewer = new CallerContext("user-3", UserRole.User, org.Id);
+
+        await Should.ThrowAsync<UnauthorizedAccessException>(() =>
+            service.AddDisplayAsync(org.Id, PublicOutputName, viewer, OutputKind.PublicQr));
+    }
+
+    private class TestDbContextFactory(DbContextOptions<PresentationContext> options)
+        : IDbContextFactory<PresentationContext>
+    {
+        public PresentationContext CreateDbContext() => new(options);
+    }
+}

--- a/GospelPresenter/GospelPresenter.UnitTests/State/PublicOutputBroadcasterTests.cs
+++ b/GospelPresenter/GospelPresenter.UnitTests/State/PublicOutputBroadcasterTests.cs
@@ -1,0 +1,199 @@
+using GospelPresenter.Shared.Services;
+using GospelPresenter.Shared.State;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace GospelPresenter.UnitTests.State;
+
+public class PublicOutputBroadcasterTests : IDisposable
+{
+    private const string OutputCode = "abc1234";
+    private const string SessionId = "sess1234";
+    private const string OrganizationId = "org-1";
+    private const string LyricLine = "Amazing grace how sweet the sound";
+
+    private readonly ServiceProvider services;
+    private readonly SharedAppState sharedAppState = new(TimeSpan.FromMinutes(240));
+    private readonly RemoteDisplayState remoteDisplayState = new();
+    private readonly PublicOutputState publicOutputState = new();
+    private readonly PublicOutputBroadcaster broadcaster;
+
+    public PublicOutputBroadcasterTests()
+    {
+        services = new ServiceCollection()
+            .AddLogging()
+            .AddLocalization()
+            .BuildServiceProvider();
+
+        broadcaster = new PublicOutputBroadcaster(
+            services,
+            services.GetRequiredService<ILoggerFactory>(),
+            sharedAppState,
+            remoteDisplayState,
+            publicOutputState);
+    }
+
+    public void Dispose()
+    {
+        broadcaster.Dispose();
+        services.Dispose();
+    }
+
+    [Fact]
+    public async Task GetCurrentEventAsync_WhenNoPresentationIsBoundToTheOutput_ReturnsIdle()
+    {
+        var result = await broadcaster.GetCurrentEventAsync(OutputCode);
+
+        result.Type.ShouldBe(PublicOutputEventType.Idle);
+    }
+
+    [Fact]
+    public async Task GetCurrentEventAsync_WhenTheBoundPresentationIsNotShowing_ReturnsIdle()
+    {
+        remoteDisplayState.EnableDisplay(OutputCode, SessionId);
+
+        var result = await broadcaster.GetCurrentEventAsync(OutputCode);
+
+        result.Type.ShouldBe(PublicOutputEventType.Idle);
+    }
+
+    [Fact]
+    public async Task GetCurrentEventAsync_WhenShowingASong_ReturnsTheRenderedSlide()
+    {
+        StartBroadcastingSong();
+
+        var result = await broadcaster.GetCurrentEventAsync(OutputCode);
+
+        result.Type.ShouldBe(PublicOutputEventType.Slide);
+        result.Html.ShouldNotBeNull();
+        result.Html.ShouldContain(LyricLine);
+    }
+
+    [Fact]
+    public async Task GetCurrentEventAsync_WhenShowingABlackScreen_ReturnsIdle()
+    {
+        StartBroadcastingSong();
+        sharedAppState.ToggleBlackScreen(SessionId);
+
+        var result = await broadcaster.GetCurrentEventAsync(OutputCode);
+
+        // A visitor holding a phone cannot tell an all-black page from a broken one, so a black
+        // screen shows the waiting screen instead of nothing at all.
+        result.Type.ShouldBe(PublicOutputEventType.Idle);
+    }
+
+    [Fact]
+    public async Task GetCurrentEventAsync_AfterTheOutputIsSwitchedOff_ReturnsIdle()
+    {
+        StartBroadcastingSong();
+        remoteDisplayState.DisableDisplay(OutputCode, SessionId);
+
+        var result = await broadcaster.GetCurrentEventAsync(OutputCode);
+
+        result.Type.ShouldBe(PublicOutputEventType.Idle);
+    }
+
+    [Fact]
+    public async Task GetCurrentEventAsync_RewritesImageUrlsThroughTheOutputProxy()
+    {
+        var liveImageUrl = ImageUrlHelper.LiveSlidesPageUrl(SessionId, "slides-1", 3);
+        StartBroadcasting(new LiveSlide(
+            LiveSlideStatus.ShowingPresentation,
+            ProjectItemType.Slides,
+            "item-1",
+            0,
+            null,
+            null,
+            liveImageUrl,
+            null));
+
+        var result = await broadcaster.GetCurrentEventAsync(OutputCode);
+
+        // The operator's session id must never reach a visitor's device: knowing it grants
+        // access to the unauthenticated /live view for as long as the presentation runs.
+        result.Html.ShouldNotBeNull();
+        result.Html.ShouldNotContain(SessionId);
+        result.Html.ShouldContain($"/api/watch/{OutputCode}/image/slides/slides-1/3");
+    }
+
+    [Fact]
+    public void GetBroadcastingOrganizationId_WhenNothingIsBroadcasting_ReturnsNull()
+    {
+        // This is the gate on the image proxy: no organisation means no image is served.
+        broadcaster.GetBroadcastingOrganizationId(OutputCode).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetBroadcastingOrganizationId_WhenTheBoundPresentationIsNotShowing_ReturnsNull()
+    {
+        remoteDisplayState.EnableDisplay(OutputCode, SessionId);
+
+        broadcaster.GetBroadcastingOrganizationId(OutputCode).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetBroadcastingOrganizationId_WhileBroadcasting_ReturnsTheOrganization()
+    {
+        StartBroadcastingSong();
+
+        broadcaster.GetBroadcastingOrganizationId(OutputCode).ShouldBe(OrganizationId);
+    }
+
+    [Fact]
+    public void GetBroadcastingOrganizationId_AfterTheOutputIsSwitchedOff_ReturnsNull()
+    {
+        StartBroadcastingSong();
+        remoteDisplayState.DisableDisplay(OutputCode, SessionId);
+
+        // Switching an output off must stop its images immediately, not at the next timeout.
+        broadcaster.GetBroadcastingOrganizationId(OutputCode).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetBroadcastingOrganizationId_ForAnotherOutputCode_ReturnsNull()
+    {
+        StartBroadcastingSong();
+
+        broadcaster.GetBroadcastingOrganizationId("zzz9999").ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetCurrentEventAsync_WhenShowingBibleText_ReturnsTheRenderedText()
+    {
+        StartBroadcasting(new LiveSlide(
+            LiveSlideStatus.ShowingPresentation,
+            ProjectItemType.BibleText,
+            "item-1",
+            0,
+            "For God so loved the world",
+            "John 3:16",
+            null,
+            null));
+
+        var result = await broadcaster.GetCurrentEventAsync(OutputCode);
+
+        result.Type.ShouldBe(PublicOutputEventType.Slide);
+        result.Html.ShouldNotBeNull();
+        result.Html.ShouldContain("For God so loved the world");
+        result.Html.ShouldContain("John 3:16");
+    }
+
+    private void StartBroadcastingSong() =>
+        StartBroadcasting(new LiveSlide(
+            LiveSlideStatus.ShowingPresentation,
+            ProjectItemType.Song,
+            "item-1",
+            0,
+            null,
+            null,
+            null,
+            new SongPart("part-1", null, null, null, LyricLine)));
+
+    private void StartBroadcasting(LiveSlide slide)
+    {
+        remoteDisplayState.EnableDisplay(OutputCode, SessionId);
+        sharedAppState.ActivatePresentation(SessionId, OrganizationId, "presentation-1", "Sunday service");
+        sharedAppState.SetLiveSlide(SessionId, slide);
+    }
+}

--- a/GospelPresenter/GospelPresenter.UnitTests/State/PublicOutputStateTests.cs
+++ b/GospelPresenter/GospelPresenter.UnitTests/State/PublicOutputStateTests.cs
@@ -1,0 +1,186 @@
+using GospelPresenter.Shared.State;
+using Shouldly;
+
+namespace GospelPresenter.UnitTests.State;
+
+public class PublicOutputStateTests
+{
+    private const string Code = "abc1234";
+    private const string OtherCode = "xyz9876";
+    private const string ViewerA = "viewer-a";
+    private const string ViewerB = "viewer-b";
+
+    private readonly PublicOutputState state = new();
+
+    [Fact]
+    public void GetViewerCount_ForUnknownCode_ReturnsZero()
+    {
+        state.GetViewerCount(Code).ShouldBe(0);
+    }
+
+    [Fact]
+    public void TryAddViewer_AddsViewer()
+    {
+        var added = state.TryAddViewer(Code, ViewerA, out _);
+
+        added.ShouldBeTrue();
+        state.GetViewerCount(Code).ShouldBe(1);
+    }
+
+    [Fact]
+    public void TryAddViewer_WithSameViewerIdTwice_CountsOnce()
+    {
+        state.TryAddViewer(Code, ViewerA, out _);
+        state.TryAddViewer(Code, ViewerA, out _);
+
+        state.GetViewerCount(Code).ShouldBe(1);
+    }
+
+    [Fact]
+    public void TryAddViewer_WithDifferentViewerIds_CountsEach()
+    {
+        state.TryAddViewer(Code, ViewerA, out _);
+        state.TryAddViewer(Code, ViewerB, out _);
+
+        state.GetViewerCount(Code).ShouldBe(2);
+    }
+
+    [Fact]
+    public void TryAddViewer_CountsPerOutput()
+    {
+        state.TryAddViewer(Code, ViewerA, out _);
+        state.TryAddViewer(OtherCode, ViewerB, out _);
+
+        state.GetViewerCount(Code).ShouldBe(1);
+        state.GetViewerCount(OtherCode).ShouldBe(1);
+    }
+
+    [Fact]
+    public void TryAddViewer_WhenReconnecting_CompletesThePreviousChannel()
+    {
+        state.TryAddViewer(Code, ViewerA, out var first);
+        state.TryAddViewer(Code, ViewerA, out var second);
+
+        first.Completion.IsCompleted.ShouldBeTrue();
+        second.Completion.IsCompleted.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryAddViewer_AtCap_RejectsNewViewer()
+    {
+        var capped = new PublicOutputState(maxViewersPerOutput: 1);
+        capped.TryAddViewer(Code, ViewerA, out _);
+
+        var added = capped.TryAddViewer(Code, ViewerB, out _);
+
+        added.ShouldBeFalse();
+        capped.GetViewerCount(Code).ShouldBe(1);
+    }
+
+    [Fact]
+    public void TryAddViewer_AtCap_StillAcceptsAnAlreadyRegisteredViewer()
+    {
+        var capped = new PublicOutputState(maxViewersPerOutput: 1);
+        capped.TryAddViewer(Code, ViewerA, out _);
+
+        // A viewer that is already counted is reconnecting, not arriving — rejecting it would
+        // break the page of someone who merely locked their phone.
+        var added = capped.TryAddViewer(Code, ViewerA, out _);
+
+        added.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RemoveViewer_DecreasesCount()
+    {
+        state.TryAddViewer(Code, ViewerA, out _);
+        state.TryAddViewer(Code, ViewerB, out _);
+
+        state.RemoveViewer(Code, ViewerA);
+
+        state.GetViewerCount(Code).ShouldBe(1);
+    }
+
+    [Fact]
+    public void RemoveViewer_ForLastViewer_ForgetsTheOutput()
+    {
+        state.TryAddViewer(Code, ViewerA, out _);
+
+        state.RemoveViewer(Code, ViewerA);
+
+        state.GetCodesWithViewers().ShouldNotContain(Code);
+    }
+
+    [Fact]
+    public void RemoveViewer_ForUnknownViewer_DoesNothing()
+    {
+        state.TryAddViewer(Code, ViewerA, out _);
+
+        state.RemoveViewer(Code, ViewerB);
+
+        state.GetViewerCount(Code).ShouldBe(1);
+    }
+
+    [Fact]
+    public void RemoveAllViewers_RemovesEveryoneAndCompletesTheirChannels()
+    {
+        state.TryAddViewer(Code, ViewerA, out var readerA);
+        state.TryAddViewer(Code, ViewerB, out var readerB);
+
+        state.RemoveAllViewers(Code);
+
+        state.GetViewerCount(Code).ShouldBe(0);
+        readerA.Completion.IsCompleted.ShouldBeTrue();
+        readerB.Completion.IsCompleted.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetCodesWithViewers_ReturnsOnlyOutputsThatHaveViewers()
+    {
+        state.TryAddViewer(Code, ViewerA, out _);
+
+        state.GetCodesWithViewers().ShouldBe([Code]);
+    }
+
+    [Fact]
+    public async Task Publish_DeliversTheEventToEveryViewer()
+    {
+        state.TryAddViewer(Code, ViewerA, out var readerA);
+        state.TryAddViewer(Code, ViewerB, out var readerB);
+
+        state.Publish(Code, PublicOutputEvent.Slide("<p>Amazing grace</p>"));
+
+        (await readerA.ReadAsync()).Html.ShouldBe("<p>Amazing grace</p>");
+        (await readerB.ReadAsync()).Html.ShouldBe("<p>Amazing grace</p>");
+    }
+
+    [Fact]
+    public async Task Publish_WhenAViewerHasNotKeptUp_DeliversOnlyTheLatestEvent()
+    {
+        state.TryAddViewer(Code, ViewerA, out var reader);
+
+        state.Publish(Code, PublicOutputEvent.Slide("<p>First</p>"));
+        state.Publish(Code, PublicOutputEvent.Slide("<p>Second</p>"));
+
+        // Only the current slide matters, so a stalled viewer catches up rather than replaying.
+        (await reader.ReadAsync()).Html.ShouldBe("<p>Second</p>");
+        reader.TryRead(out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Publish_WithNoViewers_DoesNothing()
+    {
+        Should.NotThrow(() => state.Publish(Code, PublicOutputEvent.Idle));
+    }
+
+    [Fact]
+    public void ViewerCountChanged_IsRaisedWhenTheFirstViewerArrives()
+    {
+        var raisedFor = new List<string>();
+        state.ViewerCountChanged += code => raisedFor.Add(code);
+
+        state.TryAddViewer(Code, ViewerA, out _);
+
+        raisedFor.ShouldBe([Code]);
+    }
+}

--- a/GospelPresenter/GospelPresenter.Web/Program.cs
+++ b/GospelPresenter/GospelPresenter.Web/Program.cs
@@ -265,9 +265,8 @@ builder.Services.AddMetricServer(options =>
     {
         await using var scope = app.Services.CreateAsyncScope();
         var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<PresentationContext>>();
-        await using var db = await dbFactory.CreateDbContextAsync();
-        await db.Database.EnsureCreatedAsync();
-        await MockDataSeeder.SeedAsync(db);
+        await MockDatabaseInitializer.InitializeAsync(
+            dbFactory, app.Services.GetRequiredService<ILogger<Program>>());
     }
 
     {
@@ -333,6 +332,8 @@ builder.Services.AddMetricServer(options =>
                                      || path.StartsWith("/_", StringComparison.OrdinalIgnoreCase)
                                      || path.StartsWith("/health", StringComparison.OrdinalIgnoreCase)
                                      || path.StartsWith("/api/calendar/", StringComparison.OrdinalIgnoreCase)
+                                     || path.StartsWith("/watch/", StringComparison.OrdinalIgnoreCase)
+                                     || path.StartsWith("/api/watch/", StringComparison.OrdinalIgnoreCase)
                                      || path.Equals("/live", StringComparison.OrdinalIgnoreCase)
                                      || path.Equals("/display", StringComparison.OrdinalIgnoreCase);
                     if (!isPublicPath)
@@ -687,6 +688,11 @@ builder.Services.AddMetricServer(options =>
     }).RequireAuthorization();
 
     app.MapCalendarEndpoints();
+    app.MapPublicOutputEndpoints();
+
+    // Resolve the broadcaster eagerly: it subscribes to live-state events in its constructor,
+    // and a lazily created singleton would miss every change until the first visitor connected.
+    app.Services.GetRequiredService<PublicOutputBroadcaster>();
 
     // MCP API key authentication middleware
     app.Use(async (context, next) =>

--- a/GospelPresenter/GospelPresenter.Web/PublicOutputEndpoints.cs
+++ b/GospelPresenter/GospelPresenter.Web/PublicOutputEndpoints.cs
@@ -1,0 +1,206 @@
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+using GospelPresenter.Shared.Components.Presentations;
+using GospelPresenter.Shared.Services;
+using GospelPresenter.Shared.State;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GospelPresenter.Web;
+
+/// <summary>
+/// Anonymous endpoints for public outputs — the pages and streams a visitor reaches by scanning
+/// an output's QR code.
+///
+/// These are deliberately plain minimal-API endpoints rather than Razor routes: App.razor mounts
+/// the router with an interactive render mode, so a routed page would give every visitor a Blazor
+/// circuit. See PublicWatchPage.razor for the reasoning.
+/// </summary>
+public static class PublicOutputEndpoints
+{
+    private static readonly TimeSpan PingInterval = TimeSpan.FromSeconds(15);
+
+    public static void MapPublicOutputEndpoints(this WebApplication app)
+    {
+        MapWatchPage(app);
+        MapEventStream(app);
+        MapImageProxy(app);
+    }
+
+    private static void MapWatchPage(WebApplication app)
+    {
+        app.MapGet("/watch/{code}", async (
+            string code,
+            HttpContext httpContext,
+            [FromServices] IRemoteDisplayService remoteDisplayService,
+            [FromServices] ILoggerFactory loggerFactory) =>
+        {
+            var output = await remoteDisplayService.FindPublicOutputAsync(code);
+            if (output is null)
+                return Results.NotFound();
+
+            var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+            {
+                [nameof(PublicWatchPage.Code)] = output.DisplayIdentifier,
+                [nameof(PublicWatchPage.OrganizationName)] = output.Organization?.Name,
+                [nameof(PublicWatchPage.OutputName)] = output.Name
+            });
+
+            // Rendered per request so the waiting screen follows the visitor's Accept-Language.
+            await using var renderer = new HtmlRenderer(httpContext.RequestServices, loggerFactory);
+            var html = await renderer.Dispatcher.InvokeAsync(async () =>
+                (await renderer.RenderComponentAsync<PublicWatchPage>(parameters)).ToHtmlString());
+
+            return Results.Content(html, "text/html; charset=utf-8");
+        }).AllowAnonymous();
+    }
+
+    private static void MapEventStream(WebApplication app)
+    {
+        app.MapGet("/api/watch/{code}/stream", async (
+            string code,
+            [FromQuery(Name = "v")] string? v,
+            HttpContext httpContext,
+            [FromServices] IRemoteDisplayService remoteDisplayService,
+            [FromServices] PublicOutputState publicOutputState,
+            [FromServices] PublicOutputBroadcaster broadcaster,
+            CancellationToken cancellationToken) =>
+        {
+            var output = await remoteDisplayService.FindPublicOutputAsync(code);
+            if (output is null)
+                return Results.NotFound();
+
+            if (string.IsNullOrWhiteSpace(v))
+                return Results.BadRequest();
+
+            var viewerId = v;
+            var response = httpContext.Response;
+            response.Headers.ContentType = "text/event-stream";
+            response.Headers.CacheControl = "no-cache, no-store";
+            // Tell any reverse proxy not to buffer the stream, or slides arrive in batches.
+            response.Headers["X-Accel-Buffering"] = "no";
+
+            if (!publicOutputState.TryAddViewer(output.DisplayIdentifier, viewerId, out var reader))
+            {
+                await WriteEventAsync(response, "full", null, cancellationToken);
+                return Results.Empty;
+            }
+
+            try
+            {
+                var current = await broadcaster.GetCurrentEventAsync(output.DisplayIdentifier);
+                await WriteOutputEventAsync(response, current, cancellationToken);
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    // Either the next state change or a keep-alive, whichever comes first. The
+                    // ping is what detects a phone that went away without closing the socket.
+                    using var pingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    pingCts.CancelAfter(PingInterval);
+
+                    try
+                    {
+                        var evt = await reader.ReadAsync(pingCts.Token);
+                        await WriteOutputEventAsync(response, evt, cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                    {
+                        await response.WriteAsync(":ping\n\n", cancellationToken);
+                        await response.Body.FlushAsync(cancellationToken);
+                        publicOutputState.TouchViewer(output.DisplayIdentifier, viewerId);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // The visitor navigated away, locked the screen, or lost the network.
+            }
+            catch (ChannelClosedException)
+            {
+                // The output was removed or its code regenerated while this viewer was connected.
+            }
+            finally
+            {
+                publicOutputState.RemoveViewer(output.DisplayIdentifier, viewerId);
+            }
+
+            return Results.Empty;
+        }).AllowAnonymous();
+    }
+
+    private static void MapImageProxy(WebApplication app)
+    {
+        // Imported presentation pages.
+        app.MapGet("/api/watch/{code}/image/slides/{slidesId}/{page:int}", async (
+            string code, string slidesId, int page,
+            HttpContext context,
+            [FromServices] PublicOutputBroadcaster broadcaster,
+            [FromServices] IObjectStorageService storage) =>
+        {
+            var orgId = broadcaster.GetBroadcastingOrganizationId(code);
+            if (orgId is null) return Results.NotFound();
+
+            return await ServeAsync(context, storage, ImageUrlHelper.SlidesPageKey(orgId, slidesId, page));
+        }).AllowAnonymous();
+
+        // Organisation images and overlay images.
+        app.MapGet("/api/watch/{code}/image/{type}/{id}/{variant}", async (
+            string code, string type, string id, string variant,
+            HttpContext context,
+            [FromServices] PublicOutputBroadcaster broadcaster,
+            [FromServices] IObjectStorageService storage) =>
+        {
+            var orgId = broadcaster.GetBroadcastingOrganizationId(code);
+            if (orgId is null) return Results.NotFound();
+
+            var s3Key = type switch
+            {
+                "org-image" => ImageUrlHelper.OrgImageKey(orgId, id, variant),
+                "overlay" => ImageUrlHelper.OverlayImageKey(orgId, id),
+                _ => null
+            };
+
+            if (s3Key is null) return Results.NotFound();
+
+            return await ServeAsync(context, storage, s3Key);
+        }).AllowAnonymous();
+    }
+
+    private static async Task<IResult> ServeAsync(
+        HttpContext context, IObjectStorageService storage, string s3Key)
+    {
+        var result = await storage.GetAsync(s3Key);
+        if (result is null) return Results.NotFound();
+
+        var (stream, contentType) = result.Value;
+        context.Response.Headers.CacheControl = "public, max-age=3600";
+        return Results.File(stream, contentType);
+    }
+
+    private static Task WriteOutputEventAsync(
+        HttpResponse response, PublicOutputEvent evt, CancellationToken cancellationToken)
+    {
+        return evt.Type switch
+        {
+            PublicOutputEventType.Slide => WriteEventAsync(response, "slide", evt.Html, cancellationToken),
+            _ => WriteEventAsync(response, "idle", null, cancellationToken)
+        };
+    }
+
+    private static async Task WriteEventAsync(
+        HttpResponse response, string eventName, string? payload, CancellationToken cancellationToken)
+    {
+        // The payload is JSON-encoded so that an HTML fragment containing newlines still fits on
+        // a single SSE data line.
+        var data = JsonSerializer.Serialize(payload ?? "");
+
+        var builder = new StringBuilder()
+            .Append("event: ").Append(eventName).Append('\n')
+            .Append("data: ").Append(data).Append("\n\n");
+
+        await response.WriteAsync(builder.ToString(), cancellationToken);
+        await response.Body.FlushAsync(cancellationToken);
+    }
+}

--- a/GospelPresenter/GospelPresenter.Web/Services/MockDatabaseInitializer.cs
+++ b/GospelPresenter/GospelPresenter.Web/Services/MockDatabaseInitializer.cs
@@ -1,0 +1,121 @@
+using System.Data.Common;
+using System.Security.Cryptography;
+using System.Text;
+using GospelPresenter.Shared.Contexts;
+using Microsoft.EntityFrameworkCore;
+
+namespace GospelPresenter.Web.Services;
+
+/// <summary>
+/// Creates the SQLite mock database used when no real connection string is configured, and
+/// rebuilds it from scratch whenever the model has changed since it was created.
+///
+/// Mock mode uses EnsureCreated rather than migrations, because the migrations are written for
+/// Npgsql and their SQL does not all apply to SQLite. EnsureCreated does nothing at all when the
+/// file already exists, so before this a model change left developers with a database missing the
+/// new columns and a runtime error such as "no such column: r.Kind" — with no hint that the fix
+/// was to delete the file.
+///
+/// The database is disposable scratch data that is reseeded on creation, so recreating it is the
+/// right response to a schema change. NEVER call this for a real database.
+/// </summary>
+public static class MockDatabaseInitializer
+{
+    private const string SchemaTable = "__MockSchema";
+
+    public static async Task InitializeAsync(
+        IDbContextFactory<PresentationContext> dbContextFactory, ILogger logger)
+    {
+        string fingerprint;
+
+        // The connection is never held open across the delete: EF opens and closes it around
+        // each call below. A connection left open would keep the deleted file alive behind the
+        // scenes, and the schema EF then sees stops matching what is on disk.
+        await using (var probe = await dbContextFactory.CreateDbContextAsync())
+        {
+            fingerprint = ComputeSchemaFingerprint(probe);
+
+            if (await probe.Database.CanConnectAsync())
+            {
+                var existing = await ReadFingerprintAsync(probe);
+                if (existing != fingerprint)
+                {
+                    logger.LogWarning(
+                        "Mock database schema is out of date (found {Existing}, expected {Expected}) — recreating and reseeding it.",
+                        existing ?? "no fingerprint", fingerprint);
+
+                    await DeleteDatabaseAsync(probe, logger);
+                }
+            }
+        }
+
+        // A fresh context, so nothing about the deleted database is carried over.
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        await db.Database.EnsureCreatedAsync();
+        await WriteFingerprintAsync(db, fingerprint);
+        await MockDataSeeder.SeedAsync(db);
+    }
+
+    /// <summary>
+    /// A hash of the schema EnsureCreated would produce for the current model. Any added,
+    /// removed or altered table, column or index changes it.
+    /// </summary>
+    private static string ComputeSchemaFingerprint(PresentationContext db)
+    {
+        var script = db.Database.GenerateCreateScript();
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(script));
+        return Convert.ToHexString(hash)[..16];
+    }
+
+    private static async Task<string?> ReadFingerprintAsync(PresentationContext db)
+    {
+        try
+        {
+            // EF requires the column of a scalar SqlQueryRaw result to be named "Value".
+            return await db.Database
+                .SqlQueryRaw<string>($"SELECT Fingerprint AS Value FROM {SchemaTable} LIMIT 1")
+                .FirstOrDefaultAsync();
+        }
+        catch (DbException)
+        {
+            // No such table: a database created before fingerprinting existed. Treat it as
+            // out of date, which it may well be.
+            return null;
+        }
+    }
+
+    private static async Task WriteFingerprintAsync(PresentationContext db, string fingerprint)
+    {
+        await db.Database.ExecuteSqlRawAsync(
+            $"CREATE TABLE IF NOT EXISTS {SchemaTable} (Fingerprint TEXT NOT NULL)");
+        await db.Database.ExecuteSqlRawAsync($"DELETE FROM {SchemaTable}");
+        await db.Database.ExecuteSqlRawAsync(
+            $"INSERT INTO {SchemaTable} (Fingerprint) VALUES ({{0}})", fingerprint);
+    }
+
+    private static async Task DeleteDatabaseAsync(PresentationContext db, ILogger logger)
+    {
+        // Captured before deleting, while the connection still knows where the file lives.
+        var dataSource = db.Database.GetDbConnection().DataSource;
+
+        await db.Database.EnsureDeletedAsync();
+
+        // EnsureDeleted removes the database file itself but leaves SQLite's write-ahead log
+        // beside it. A stale log next to a brand new database is discarded by SQLite, but
+        // removing it keeps the directory honest about what exists.
+        if (string.IsNullOrEmpty(dataSource))
+            return;
+
+        foreach (var suffix in (string[])["-wal", "-shm"])
+        {
+            try
+            {
+                File.Delete(dataSource + suffix);
+            }
+            catch (IOException ex)
+            {
+                logger.LogDebug(ex, "Could not remove {File}", dataSource + suffix);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a new kind of output: a QR code that any visitor can scan to follow the live presentation on their own phone.

## What it does

- A **public output** is created on `/admin/displays`, alongside the existing screens, and gets a stable 7-character code plus a QR code that can be downloaded as an image — so it can be printed for a sign in the entrance, or added to a presentation as an ordinary image or overlay to project before a service.
- It is switched on per presentation in the live panel, which also shows **how many devices are connected right now**.
- Only one presentation can broadcast to an output at a time. Taking one over is confirmed and names the presentation currently broadcasting, rather than being silent — nobody stands next to a congregation's phones to notice that the wrong presentation started sending to them.

## Design decisions worth reviewing

**The viewer page is not a Razor route.** `App.razor` mounts the router with `@rendermode="InteractiveServer"`, so a routed page would open a Blazor circuit per visitor. That is expensive at congregation scale, and it breaks the moment a phone locks its screen: the socket dies and Blazor eventually stops reconnecting. `/watch/{code}` is therefore served as plain HTML plus an SSE stream, which `EventSource` reconnects on its own. The slide is rendered once per change with `HtmlRenderer` and the same HTML is pushed to every viewer, so a bigger audience costs one open response per person instead of a render and a diff per person.

**Text reflows instead of being letterboxed.** Scaling the 1920x1080 canvas into a portrait phone leaves the default 85px song text at about 17px. `PublicSlideView` keeps the organisation's font family, weight and line height but sizes the text from the viewport, capped at the configured size, so a desktop viewer still sees the slide as designed. Song line breaks are preserved. Images and imported presentation pages cannot reflow and fill the width.

**Images are proxied through the output code.** Live image URLs embed the operator's `sessionId`, and knowing it grants access to the unauthenticated `/live` view for as long as the presentation runs. Sending that to every visitor would make the output a permanent back door, so the URLs are rewritten to `/api/watch/{code}/image/...`. Switching the output off stops the images immediately.

**The waiting screen never goes fully black.** A blank page on a phone is indistinguishable from a broken one. Before the broadcast starts, during a black screen and after it stops, the viewer sees the output's name and a quiet "waiting" indicator.

**Model kind rather than a new entity.** `OutputKind { Screen, PublicQr }` on `RemoteDisplay` reuses the admin CRUD, the unique code generation, the binding registry that gives exclusivity, and the live panel list.

## Also included

The mock SQLite database is now fingerprinted against the model and recreated when the two no longer match. Mock mode uses `EnsureCreated` rather than migrations, so before this the migration in this PR left developers with a stale schema and a runtime error (`no such column: r.Kind`) with no hint that the fix was to delete the file.

## Verification

185 unit tests pass, covering viewer counting and deduplication, the broadcast states, the image-proxy gate, and code regeneration.

Verified end to end in the browser: creating an output, two viewers connecting (count `2`), reload not double-counting, closing a tab dropping to `1`, switching the output off returning viewers to the waiting screen, takeover naming the broadcasting presentation and viewers following without rescanning, no `sessionId` anywhere in what is sent to viewers, `noindex` present, and readable lyrics on a 375x812 phone.

Mock database recreation verified against a genuinely stale database, an unchanged schema (left alone), and a real model change (rebuilt).

## Notes

- Protections on the public URL: `noindex, nofollow`, code regeneration in admin, and a configurable `Settings:PublicOutputMaxViewers` (default 500) as a safety valve.
- The image proxy returns 500 rather than 404 in mock mode, because `NullObjectStorageService` throws when S3 is not configured. The existing `/api/live-images` endpoints behave identically; this follows the pattern rather than diverging in one endpoint.
- Single instance only, as before: the state singletons are process-local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)