### PR TITLE
Make stage mode usable with a foot pedal

### DIFF
--- a/GospelPresenter/GospelPresenter.Shared/Components/Presentations/StageView.razor
+++ b/GospelPresenter/GospelPresenter.Shared/Components/Presentations/StageView.razor
@@ -311,6 +311,7 @@
     private bool showOverlayDrawer;
     private DotNetObjectReference<StageView>? dotNetRef;
     private bool keysInstalled;
+    private bool wakeLockRequested;
     private string? lastScrolledPartKey;
 
     private record StageScales(double Current, double Next, double Strip);
@@ -460,6 +461,10 @@
             dotNetRef = DotNetObjectReference.Create(this);
             try { await JsRuntime.InvokeVoidAsync("gospelPresenter.installStageKeys", dotNetRef); keysInstalled = true; } catch { }
 
+            // Stage mode is driven by keys, often from a foot pedal, so the device must not fall
+            // asleep between presses.
+            try { await JsRuntime.InvokeVoidAsync("gospelPresenter.requestStageWakeLock"); wakeLockRequested = true; } catch { }
+
             // Nothing selected on entry → open the picker straight away so the leader can act.
             if (SelectedItem is null && Items.Count > 0)
             {
@@ -514,6 +519,10 @@
         if (keysInstalled)
         {
             try { await JsRuntime.InvokeVoidAsync("gospelPresenter.uninstallStageKeys"); } catch { }
+        }
+        if (wakeLockRequested)
+        {
+            try { await JsRuntime.InvokeVoidAsync("gospelPresenter.releaseStageWakeLock"); } catch { }
         }
         dotNetRef?.Dispose();
     }

--- a/GospelPresenter/GospelPresenter.Shared/wwwroot/utils.js
+++ b/GospelPresenter/GospelPresenter.Shared/wwwroot/utils.js
@@ -1003,12 +1003,18 @@ window.gospelPresenter.installStageKeys = function(dotNetRef) {
             return;
         }
         var action = null;
+        // Foot pedals and presentation clickers are HID keyboards. Which keys they send is
+        // switchable on the pedal itself, so cover the modes they ship with: right/left arrows,
+        // down/up arrows, page down/up, space and enter.
         switch (e.key) {
             case 'ArrowRight':
+            case 'ArrowDown':
             case 'PageDown':
             case ' ':
+            case 'Enter':
                 action = 'next'; break;
             case 'ArrowLeft':
+            case 'ArrowUp':
             case 'PageUp':
                 action = 'prev'; break;
             case '.':
@@ -1029,6 +1035,55 @@ window.gospelPresenter.uninstallStageKeys = function() {
     if (window.gospelPresenter._stageKeyHandler) {
         document.removeEventListener('keydown', window.gospelPresenter._stageKeyHandler);
         window.gospelPresenter._stageKeyHandler = null;
+    }
+};
+
+// Keeps the screen awake while stage mode is open. A phone that locks its screen drops the
+// Blazor circuit, and a foot pedal cannot wake it again — it only sends a keystroke to a
+// sleeping device. Without this the pedal works in a demo and stops working mid-talk.
+window.gospelPresenter._stageWakeLock = null;
+window.gospelPresenter._stageWakeLockVisibilityHandler = null;
+
+window.gospelPresenter.requestStageWakeLock = async function() {
+    if (!('wakeLock' in navigator)) return;
+
+    var acquire = async function() {
+        try {
+            var lock = await navigator.wakeLock.request('screen');
+            window.gospelPresenter._stageWakeLock = lock;
+            // The system may drop the lock on its own; forget it so we can take it again.
+            lock.addEventListener('release', function() {
+                window.gospelPresenter._stageWakeLock = null;
+            });
+        } catch (e) {
+            // Denied, for example by battery saver. Stage mode still works, the screen just
+            // sleeps as usual.
+            window.gospelPresenter._stageWakeLock = null;
+        }
+    };
+
+    await acquire();
+
+    // The lock is always released while the page is hidden, so take it again on return.
+    if (!window.gospelPresenter._stageWakeLockVisibilityHandler) {
+        window.gospelPresenter._stageWakeLockVisibilityHandler = function() {
+            if (document.visibilityState === 'visible' && !window.gospelPresenter._stageWakeLock) {
+                acquire();
+            }
+        };
+        document.addEventListener('visibilitychange', window.gospelPresenter._stageWakeLockVisibilityHandler);
+    }
+};
+
+window.gospelPresenter.releaseStageWakeLock = function() {
+    if (window.gospelPresenter._stageWakeLockVisibilityHandler) {
+        document.removeEventListener('visibilitychange', window.gospelPresenter._stageWakeLockVisibilityHandler);
+        window.gospelPresenter._stageWakeLockVisibilityHandler = null;
+    }
+    var lock = window.gospelPresenter._stageWakeLock;
+    window.gospelPresenter._stageWakeLock = null;
+    if (lock) {
+        try { lock.release(); } catch (e) { }
     }
 };
 


### PR DESCRIPTION
Support for advancing slides with a foot pedal, so someone on stage can move
between slides without touching a device.

A foot pedal is an HID keyboard, so stage mode already responded to one out of
the box. Two things stopped it from working in practice.

## Which keys reach the handler

Pedals let you switch mode on the hardware, and up/down arrows are one of the
modes they commonly ship with. Only left/right, page up/down and space were
mapped, so a pedal used straight out of the box often did nothing at all.

Down arrow and enter now advance, up arrow goes back.

## Whether the device is awake

Stage mode holds a Blazor circuit, and a phone that locks its screen drops it.
A pedal cannot wake the phone — it only sends a keystroke to a sleeping device,
so the presenter presses and nothing happens. The codebase already knew this
failure mode; it is why `PublicWatchPage` deliberately avoids circuits.

Stage mode now takes a screen wake lock and releases it on exit. The lock is
always dropped while the page is hidden, so it is re-acquired on
`visibilitychange` — without that it would work exactly once.

Denial is swallowed: on a device or browser that refuses, stage mode works as
before and the screen just sleeps.

## Verification

The key map was tested against the JavaScript the app actually serves, by
installing the handler with a stub .NET reference and dispatching real keydown
events:

| Keys | Result |
|---|---|
| `ArrowRight` `ArrowDown` `PageDown` space `Enter` | next |
| `ArrowLeft` `ArrowUp` `PageUp` | prev |
| `.` / `Escape` | clear / exit |
| anything else | no action |

The guard against hijacking keys from a focused text field still holds: the
same key is swallowed inside an `<input>` and passes through outside one.

The real wake lock could not be taken in the preview pane — the Wake Lock spec
refuses on a hidden page (`NotAllowedError: The requesting page is not
visible`). The re-acquisition path was verified separately with a stubbed API:
the first attempt is denied, and the lock is taken once the page becomes
visible.

**Still to try on real hardware:** that the lock is actually granted on a
visible phone screen. The test that matters is leaving a phone untouched in
stage mode for ten minutes and then pressing a key.