### PR TITLE
Stop per-request database work in the authenticated pipeline

### DIFF
--- a/GospelPresenter/GospelPresenter.IntegrationTests/Fixtures/DatabaseQueryCounter.cs
+++ b/GospelPresenter/GospelPresenter.IntegrationTests/Fixtures/DatabaseQueryCounter.cs
@@ -1,0 +1,94 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace GospelPresenter.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Counts every SQL command the application sends, so a test can assert how many database
+/// round-trips a request costs. Registered as an EF Core interceptor by <see cref="WebAppFixture"/>.
+/// </summary>
+public class DatabaseQueryCounter
+{
+    private readonly Lock gate = new();
+    private readonly List<string> commands = [];
+
+    public int Count
+    {
+        get
+        {
+            lock (gate) return commands.Count;
+        }
+    }
+
+    public IReadOnlyList<string> Commands
+    {
+        get
+        {
+            lock (gate) return commands.ToList();
+        }
+    }
+
+    /// <summary>Counts the recorded commands whose SQL contains <paramref name="fragment"/>.</summary>
+    public int CountContaining(string fragment)
+    {
+        lock (gate) return commands.Count(c => c.Contains(fragment, StringComparison.Ordinal));
+    }
+
+    public void Reset()
+    {
+        lock (gate) commands.Clear();
+    }
+
+    internal void Record(string commandText)
+    {
+        lock (gate) commands.Add(commandText);
+    }
+}
+
+public class CountingCommandInterceptor(DatabaseQueryCounter counter) : DbCommandInterceptor
+{
+    public override InterceptionResult<DbDataReader> ReaderExecuting(
+        DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+    {
+        counter.Record(command.CommandText);
+        return result;
+    }
+
+    public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+        DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+        CancellationToken cancellationToken = default)
+    {
+        counter.Record(command.CommandText);
+        return ValueTask.FromResult(result);
+    }
+
+    public override InterceptionResult<object> ScalarExecuting(
+        DbCommand command, CommandEventData eventData, InterceptionResult<object> result)
+    {
+        counter.Record(command.CommandText);
+        return result;
+    }
+
+    public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
+        DbCommand command, CommandEventData eventData, InterceptionResult<object> result,
+        CancellationToken cancellationToken = default)
+    {
+        counter.Record(command.CommandText);
+        return ValueTask.FromResult(result);
+    }
+
+    public override InterceptionResult<int> NonQueryExecuting(
+        DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+    {
+        counter.Record(command.CommandText);
+        return result;
+    }
+
+    public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+        DbCommand command, CommandEventData eventData, InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        counter.Record(command.CommandText);
+        return ValueTask.FromResult(result);
+    }
+}

--- a/GospelPresenter/GospelPresenter.IntegrationTests/Fixtures/WebAppFixture.cs
+++ b/GospelPresenter/GospelPresenter.IntegrationTests/Fixtures/WebAppFixture.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using GospelPresenter.Shared.Contexts;
+using GospelPresenter.Shared.Models;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.Mvc.Testing.Handlers;
@@ -34,11 +35,20 @@ public class WebAppFixture : WebApplicationFactory<Program>
     private static readonly Uri BaseAddress = new("https://localhost/");
 
     private readonly SqliteConnection connection;
+    private CookieContainerHandler? cookies;
 
     public DatabaseQueryCounter Queries { get; } = new();
 
+    /// <summary>The cookies the client currently holds, after any redirects have been followed.</summary>
+    public CookieCollection CurrentCookies => cookies is null
+        ? []
+        : cookies.Container.GetCookies(BaseAddress);
+
     /// <summary>Zero disables the revalidation cache, so every request asks the database.</summary>
     public int RevalidationCacheSeconds { get; init; } = 30;
+
+    /// <summary>Zero disables the preferred-language cache, so every request asks the database.</summary>
+    public int PreferredLanguageCacheSeconds { get; init; } = 300;
 
     public WebAppFixture()
     {
@@ -51,6 +61,7 @@ public class WebAppFixture : WebApplicationFactory<Program>
         builder.UseEnvironment(Environments.Development);
         builder.UseSetting("ConnectionStrings:postgresdb", "");
         builder.UseSetting("Settings:SessionRevalidationCacheSeconds", RevalidationCacheSeconds.ToString());
+        builder.UseSetting("Settings:PreferredLanguageCacheSeconds", PreferredLanguageCacheSeconds.ToString());
 
         builder.ConfigureTestServices(services =>
         {
@@ -74,7 +85,7 @@ public class WebAppFixture : WebApplicationFactory<Program>
     {
         // Redirect handler first, cookie handler inside it: the sign-in endpoint answers with a 302
         // carrying the authentication cookie, and only the inner handler sees that response.
-        var cookies = new CookieContainerHandler();
+        cookies = new CookieContainerHandler();
         var client = CreateDefaultClient(BaseAddress, new RedirectHandler(), cookies);
 
         var response = await client.GetAsync($"/mock-signin/{MockUserId}");
@@ -91,6 +102,19 @@ public class WebAppFixture : WebApplicationFactory<Program>
                 cookie.Expired = true;
 
         return client;
+    }
+
+    public async Task SetPreferredLanguageAsync(string language)
+    {
+        await using var context = Services.GetRequiredService<IDbContextFactory<PresentationContext>>()
+            .CreateDbContext();
+        context.UserSettings.Add(new UserSetting
+        {
+            UserId = MockUserId,
+            Key = UserSetting.PreferredLanguage,
+            Value = language
+        });
+        await context.SaveChangesAsync();
     }
 
     public async Task DeleteMockUserAsync()

--- a/GospelPresenter/GospelPresenter.IntegrationTests/Fixtures/WebAppFixture.cs
+++ b/GospelPresenter/GospelPresenter.IntegrationTests/Fixtures/WebAppFixture.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using GospelPresenter.Shared.Contexts;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Mvc.Testing.Handlers;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+
+namespace GospelPresenter.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Boots the real application in-process against an in-memory SQLite database.
+///
+/// No connection string is supplied, which puts the app in mock-authentication mode — the only
+/// mode a test can sign in to, since the real providers need Google or OIDC. The session rules
+/// under test (cookie validation, deleted accounts) are wired identically in both modes.
+///
+/// The application seeds its own mock data on startup, so the test signs in as that user rather
+/// than creating one.
+/// </summary>
+public class WebAppFixture : WebApplicationFactory<Program>
+{
+    public const string MockUserId = "mock-user-sv";
+    private const string MockUserCookie = "mock-user-id";
+    private const string AuthCookie = ".AspNetCore.Cookies";
+
+    // The authentication cookie is issued with the Secure flag, so a client on http would never
+    // send it back. Production runs behind TLS, so https is also the realistic base address.
+    private static readonly Uri BaseAddress = new("https://localhost/");
+
+    private readonly SqliteConnection connection;
+
+    public DatabaseQueryCounter Queries { get; } = new();
+
+    /// <summary>Zero disables the revalidation cache, so every request asks the database.</summary>
+    public int RevalidationCacheSeconds { get; init; } = 30;
+
+    public WebAppFixture()
+    {
+        connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment(Environments.Development);
+        builder.UseSetting("ConnectionStrings:postgresdb", "");
+        builder.UseSetting("Settings:SessionRevalidationCacheSeconds", RevalidationCacheSeconds.ToString());
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.RemoveAll<IDbContextFactory<PresentationContext>>();
+            services.RemoveAll<DbContextOptions<PresentationContext>>();
+            services.AddDbContextFactory<PresentationContext>(options => options
+                .UseSqlite(connection)
+                .AddInterceptors(new CountingCommandInterceptor(Queries)));
+        });
+    }
+
+    /// <summary>
+    /// Signs in as the seeded mock user and returns a client holding the resulting authentication
+    /// cookie.
+    ///
+    /// The auto-sign-in cookie that mock mode also hands out is dropped afterwards: it would
+    /// silently re-authenticate the user on every later request and hide whether the cookie itself
+    /// is still being accepted, which is what these tests are about.
+    /// </summary>
+    public async Task<HttpClient> CreateAuthenticatedClientAsync()
+    {
+        // Redirect handler first, cookie handler inside it: the sign-in endpoint answers with a 302
+        // carrying the authentication cookie, and only the inner handler sees that response.
+        var cookies = new CookieContainerHandler();
+        var client = CreateDefaultClient(BaseAddress, new RedirectHandler(), cookies);
+
+        var response = await client.GetAsync($"/mock-signin/{MockUserId}");
+        response.IsSuccessStatusCode.ShouldBeTrue(
+            $"mock sign-in should succeed, got {(int)response.StatusCode}");
+
+        var jar = cookies.Container.GetCookies(BaseAddress);
+        jar.Any(c => c.Name == AuthCookie).ShouldBeTrue(
+            "sign-in should have set an authentication cookie, otherwise every later assertion "
+            + $"passes for the wrong reason; cookies were: {string.Join(", ", jar.Select(c => c.Name))}");
+
+        foreach (Cookie cookie in jar)
+            if (cookie.Name == MockUserCookie)
+                cookie.Expired = true;
+
+        return client;
+    }
+
+    public async Task DeleteMockUserAsync()
+    {
+        await using var context = Services.GetRequiredService<IDbContextFactory<PresentationContext>>()
+            .CreateDbContext();
+        await context.Users.Where(u => u.Id == MockUserId).ExecuteDeleteAsync();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing) connection.Dispose();
+    }
+}

--- a/GospelPresenter/GospelPresenter.IntegrationTests/GospelPresenter.IntegrationTests.csproj
+++ b/GospelPresenter/GospelPresenter.IntegrationTests/GospelPresenter.IntegrationTests.csproj
@@ -9,7 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="Shouldly" Version="4.3.0" />
@@ -27,6 +29,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\GospelPresenter.Shared\GospelPresenter.Shared.csproj" />
+        <ProjectReference Include="..\GospelPresenter.Web\GospelPresenter.Web.csproj" />
     </ItemGroup>
 
 </Project>

--- a/GospelPresenter/GospelPresenter.IntegrationTests/Services/SessionRevalidationIntegrationTests.cs
+++ b/GospelPresenter/GospelPresenter.IntegrationTests/Services/SessionRevalidationIntegrationTests.cs
@@ -1,0 +1,83 @@
+using GospelPresenter.IntegrationTests.Fixtures;
+using Shouldly;
+
+namespace GospelPresenter.IntegrationTests.Services;
+
+/// <summary>
+/// Covers the cookie-validation path added to keep deleted accounts from outliving their session.
+/// It fires on every request that carries the cookie, so the cost per request matters as much as
+/// the behaviour — these tests assert both.
+/// </summary>
+public class SessionRevalidationIntegrationTests
+{
+    private const string AnyPath = "/no-such-page";
+    private const int RepeatedRequests = 10;
+
+    // The account lookup reads the Users table; other per-request queries in the pipeline read
+    // other tables, so this is enough to tell the revalidation cost apart from the rest.
+    private const string AccountLookup = "FROM \"Users\"";
+
+    [Fact]
+    public async Task RepeatedRequests_WithValidSession_RevalidateTheAccountAtMostOnce()
+    {
+        // Arrange
+        using var app = new WebAppFixture();
+        var client = await app.CreateAuthenticatedClientAsync();
+        app.Queries.Reset();
+
+        // Act
+        for (var i = 0; i < RepeatedRequests; i++)
+            await client.GetAsync(AnyPath);
+
+        // Assert -- one lookup per request would mean a page load costs one query per static file
+        app.Queries.CountContaining(AccountLookup).ShouldBeLessThanOrEqualTo(1,
+            "expected the revalidation cache to absorb repeated requests, but saw: "
+            + string.Join(" | ", app.Queries.Commands));
+    }
+
+    [Fact]
+    public async Task RepeatedRequests_WithoutCache_RevalidateTheAccountEveryTime()
+    {
+        // Arrange -- guards the test above: it must pass because of the cache, not because the
+        // lookup never runs at all
+        using var app = new WebAppFixture { RevalidationCacheSeconds = 0 };
+        var client = await app.CreateAuthenticatedClientAsync();
+        app.Queries.Reset();
+
+        // Act
+        for (var i = 0; i < RepeatedRequests; i++)
+            await client.GetAsync(AnyPath);
+
+        // Assert
+        app.Queries.CountContaining(AccountLookup).ShouldBe(RepeatedRequests);
+    }
+
+    [Fact]
+    public async Task Request_AfterUserIsDeleted_IsNoLongerAuthenticated()
+    {
+        // Arrange -- no cache, so the deletion takes effect on the very next request
+        using var app = new WebAppFixture { RevalidationCacheSeconds = 0 };
+        var client = await app.CreateAuthenticatedClientAsync();
+
+        // Act
+        await app.DeleteMockUserAsync();
+        var response = await client.GetAsync(AnyPath);
+
+        // Assert -- an anonymous request is redirected to the login page instead of reaching the app
+        response.RequestMessage?.RequestUri?.AbsolutePath.ShouldBe("/mock-login");
+    }
+
+    [Fact]
+    public async Task Request_WithValidSession_ReachesTheApplication()
+    {
+        // Arrange -- guards the test above: the redirect must come from the deletion, not the setup
+        using var app = new WebAppFixture { RevalidationCacheSeconds = 0 };
+        var client = await app.CreateAuthenticatedClientAsync();
+
+        // Act
+        var response = await client.GetAsync(AnyPath);
+
+        // Assert
+        response.RequestMessage?.RequestUri?.AbsolutePath.ShouldBe(AnyPath);
+    }
+}

--- a/GospelPresenter/GospelPresenter.IntegrationTests/Services/SessionRevalidationIntegrationTests.cs
+++ b/GospelPresenter/GospelPresenter.IntegrationTests/Services/SessionRevalidationIntegrationTests.cs
@@ -1,21 +1,29 @@
 using GospelPresenter.IntegrationTests.Fixtures;
+using Microsoft.AspNetCore.Localization;
 using Shouldly;
 
 namespace GospelPresenter.IntegrationTests.Services;
 
 /// <summary>
-/// Covers the cookie-validation path added to keep deleted accounts from outliving their session.
-/// It fires on every request that carries the cookie, so the cost per request matters as much as
-/// the behaviour — these tests assert both.
+/// Covers the middleware that runs for every authenticated request: the cookie validation that
+/// keeps deleted accounts from outliving their session, and the preferred-language lookup.
+///
+/// Both sit before the static-file endpoints, so they run for each CSS file, script and image as
+/// well — the cost per request matters as much as the behaviour, and these tests assert both.
 /// </summary>
 public class SessionRevalidationIntegrationTests
 {
     private const string AnyPath = "/no-such-page";
+    private const string StaticAssetPath = "/version.json";
     private const int RepeatedRequests = 10;
 
     // The account lookup reads the Users table; other per-request queries in the pipeline read
     // other tables, so this is enough to tell the revalidation cost apart from the rest.
     private const string AccountLookup = "FROM \"Users\"";
+
+    // The preferred-language lookup is the only thing reading UserSettings on a request that
+    // renders no page.
+    private const string LanguageLookup = "FROM \"UserSettings\"";
 
     [Fact]
     public async Task RepeatedRequests_WithValidSession_RevalidateTheAccountAtMostOnce()
@@ -50,6 +58,80 @@ public class SessionRevalidationIntegrationTests
 
         // Assert
         app.Queries.CountContaining(AccountLookup).ShouldBe(RepeatedRequests);
+    }
+
+    [Fact]
+    public async Task StaticAssetRequests_CostNoDatabaseQueries()
+    {
+        // Arrange -- authenticated requests run the whole pre-endpoint pipeline even for files.
+        // Moving that middleware after MapStaticAssets does not help: app.Use always runs before
+        // endpoints execute, whatever order the Map calls appear in. Caching is what makes it free.
+        using var app = new WebAppFixture();
+        var client = await app.CreateAuthenticatedClientAsync();
+        app.Queries.Reset();
+
+        // Act
+        for (var i = 0; i < RepeatedRequests; i++)
+            (await client.GetAsync(StaticAssetPath)).EnsureSuccessStatusCode();
+
+        // Assert
+        app.Queries.Count.ShouldBe(0,
+            "a static file should not touch the database, but saw: "
+            + string.Join(" | ", app.Queries.Commands));
+    }
+
+    [Fact]
+    public async Task RepeatedRequests_WithoutStoredLanguage_LookUpTheSettingAtMostOnce()
+    {
+        // Arrange -- the seeded user has never chosen a language, so there is nothing to find
+        using var app = new WebAppFixture();
+        var client = await app.CreateAuthenticatedClientAsync();
+        app.Queries.Reset();
+
+        // Act
+        for (var i = 0; i < RepeatedRequests; i++)
+            await client.GetAsync(AnyPath);
+
+        // Assert
+        app.Queries.CountContaining(LanguageLookup).ShouldBeLessThanOrEqualTo(1,
+            "expected the miss to be remembered, but saw: " + string.Join(" | ", app.Queries.Commands));
+    }
+
+    [Fact]
+    public async Task RepeatedRequests_WithoutLanguageCache_LookUpTheSettingEveryTime()
+    {
+        // Arrange -- guards the test above: it must pass because the miss is remembered, not
+        // because the lookup stopped happening
+        using var app = new WebAppFixture { PreferredLanguageCacheSeconds = 0 };
+        var client = await app.CreateAuthenticatedClientAsync();
+        app.Queries.Reset();
+
+        // Act
+        for (var i = 0; i < RepeatedRequests; i++)
+            await client.GetAsync(AnyPath);
+
+        // Assert
+        app.Queries.CountContaining(LanguageLookup).ShouldBe(RepeatedRequests);
+    }
+
+    [Fact]
+    public async Task Request_WithStoredLanguage_StillRestoresTheCultureCookie()
+    {
+        // Arrange -- the lookup exists to restore a stored language for a browser that has lost
+        // its culture cookie; remembering misses must not break that. The cache is disabled
+        // because the sign-in request already recorded a miss for this user.
+        using var app = new WebAppFixture { PreferredLanguageCacheSeconds = 0 };
+        var client = await app.CreateAuthenticatedClientAsync();
+        await app.SetPreferredLanguageAsync("sv");
+
+        // Act
+        await client.GetAsync(AnyPath);
+
+        // Assert
+        var culture = app.CurrentCookies
+            .FirstOrDefault(c => c.Name == CookieRequestCultureProvider.DefaultCookieName);
+        culture.ShouldNotBeNull("the stored language should have been written to a culture cookie");
+        culture.Value.ShouldContain("sv");
     }
 
     [Fact]

--- a/GospelPresenter/GospelPresenter.Shared/Services/UserService.cs
+++ b/GospelPresenter/GospelPresenter.Shared/Services/UserService.cs
@@ -36,6 +36,7 @@ public interface IUserService
     Task MarkInviteUsedAsync(string inviteId);
 
     Task<bool> IsEmailTakenAsync(string email, string? excludeUserId = null);
+    Task<bool> UserExistsAsync(string id, CancellationToken cancellationToken = default);
     Task<List<User>> GetAllUsersAsync(CallerContext caller);
     Task<User?> GetByIdAsync(string id, CallerContext caller);
     Task<User> CreateUserAsync(string name, string email, string organizationId, UserRole role, CallerContext caller);
@@ -144,6 +145,17 @@ public class UserService(
         await using var context = await dbContextFactory.CreateDbContextAsync();
         return await context.Users
             .AnyAsync(u => u.Email == email && (excludeUserId == null || u.Id != excludeUserId));
+    }
+
+    /// <summary>
+    /// Checks whether a user account still exists. Used to revalidate live sessions, so it
+    /// deliberately takes no <see cref="CallerContext"/> — the caller is the session being checked.
+    /// </summary>
+    public async Task<bool> UserExistsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(id)) return false;
+        await using var context = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        return await context.Users.AnyAsync(u => u.Id == id, cancellationToken);
     }
 
     public async Task<List<User>> GetAllUsersAsync(CallerContext caller)

--- a/GospelPresenter/GospelPresenter.UnitTests/Services/UserServiceTests.cs
+++ b/GospelPresenter/GospelPresenter.UnitTests/Services/UserServiceTests.cs
@@ -224,6 +224,52 @@ public class UserServiceTests : IDisposable
             () => service.CreateMcpApiKeyAsync(ApiKeyName, user.Id, org.Id, caller));
     }
 
+    [Fact]
+    public async Task UserExistsAsync_ForExistingUser_ReturnsTrue()
+    {
+        // Act
+        var exists = await service.UserExistsAsync(user.Id);
+
+        // Assert
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UserExistsAsync_ForUnknownUser_ReturnsFalse()
+    {
+        // Act
+        var exists = await service.UserExistsAsync(UnknownUserId);
+
+        // Assert
+        exists.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task UserExistsAsync_AfterUserIsDeleted_ReturnsFalse()
+    {
+        // Arrange -- a deleted user must stop revalidating, which is what ends their live session
+        var superAdmin = AddUser(SuperAdminName, SuperAdminEmail, UserRole.SuperAdmin, org.Id);
+        await service.DeleteUserAsync(user.Id, CallerFor(superAdmin));
+
+        // Act
+        var exists = await service.UserExistsAsync(user.Id);
+
+        // Assert
+        exists.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task UserExistsAsync_WithBlankId_ReturnsFalse(string id)
+    {
+        // Act
+        var exists = await service.UserExistsAsync(id);
+
+        // Assert
+        exists.ShouldBeFalse();
+    }
+
     private User AddUserInNewOrganization()
     {
         var otherOrg = new Organization { Name = OtherOrgName };

--- a/GospelPresenter/GospelPresenter.Web/Configuration/Settings.cs
+++ b/GospelPresenter/GospelPresenter.Web/Configuration/Settings.cs
@@ -5,5 +5,14 @@ public class Settings
     public string? DataProtectionKeysDirectory { get; set; }
     public int SessionTimeoutMinutes { get; set; } = 240;
 
+    /// <summary>
+    /// How long a "this account still exists" answer is reused before the database is asked again.
+    /// The cookie is validated on every request that carries it — including each static asset — so
+    /// without this a single page load would cost one query per file. The trade-off is that a
+    /// deleted account keeps working on plain HTTP requests for at most this long; open Blazor
+    /// circuits are checked separately once a minute.
+    /// </summary>
+    public int SessionRevalidationCacheSeconds { get; set; } = 30;
+
     public static readonly string ApiBaseUrl = "";
 }

--- a/GospelPresenter/GospelPresenter.Web/Configuration/Settings.cs
+++ b/GospelPresenter/GospelPresenter.Web/Configuration/Settings.cs
@@ -14,5 +14,13 @@ public class Settings
     /// </summary>
     public int SessionRevalidationCacheSeconds { get; set; } = 30;
 
+    /// <summary>
+    /// How long "this user has not chosen a language" is remembered before the database is asked
+    /// again. Users who have chosen one are recognised by their culture cookie and never reach the
+    /// lookup, so this only affects users with nothing stored — for whom the lookup would otherwise
+    /// repeat on every request, including every static asset.
+    /// </summary>
+    public int PreferredLanguageCacheSeconds { get; set; } = 300;
+
     public static readonly string ApiBaseUrl = "";
 }

--- a/GospelPresenter/GospelPresenter.Web/Program.cs
+++ b/GospelPresenter/GospelPresenter.Web/Program.cs
@@ -405,6 +405,19 @@ builder.Services.AddMetricServer(options =>
 
     app.UseAntiforgery();
 
+    // Restores a stored language for a browser that has no culture cookie yet. A browser that has
+    // one never reaches the lookup, so only users with nothing stored do — and for them it would
+    // otherwise repeat on every single request, including every static asset, since
+    // UseAuthentication runs before the static-file endpoints. Remembering the miss collapses that
+    // to one query.
+    //
+    // Picking a language is unaffected: /culture writes the cookie in the same response as it
+    // stores the setting, so that browser short-circuits from then on. The one case a remembered
+    // miss delays is a second browser signed in as the same user, which keeps its old culture
+    // until the entry expires.
+    var noStoredLanguageCacheDuration = TimeSpan.FromSeconds(
+        app.Services.GetRequiredService<IOptions<Settings>>().Value.PreferredLanguageCacheSeconds);
+
     app.Use(async (context, next) =>
     {
         if (context.User.Identity?.IsAuthenticated == true
@@ -413,19 +426,28 @@ builder.Services.AddMetricServer(options =>
             var userId = context.User.FindFirst("user_id")?.Value;
             if (userId is not null)
             {
-                var userService = context.RequestServices.GetRequiredService<IUserService>();
-                var role = Enum.TryParse<UserRole>(context.User.FindFirst(ClaimTypes.Role)?.Value, out var r) ? r : UserRole.User;
-                var orgId = context.User.FindFirst("organization_id")?.Value;
-                var caller = new CallerContext(userId, role, orgId);
-                var lang = await userService.GetUserSettingAsync(userId, UserSetting.PreferredLanguage, caller);
-                if (lang is not null)
+                var cache = context.RequestServices.GetRequiredService<IMemoryCache>();
+                var cacheKey = $"no-preferred-language:{userId}";
+
+                if (!cache.TryGetValue(cacheKey, out _))
                 {
-                    context.Response.Cookies.Append(
-                        CookieRequestCultureProvider.DefaultCookieName,
-                        CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(lang)),
-                        new CookieOptions { Expires = DateTimeOffset.UtcNow.AddYears(1), IsEssential = true });
-                    context.Response.Redirect(context.Request.Path + context.Request.QueryString);
-                    return;
+                    var userService = context.RequestServices.GetRequiredService<IUserService>();
+                    var role = Enum.TryParse<UserRole>(context.User.FindFirst(ClaimTypes.Role)?.Value, out var r) ? r : UserRole.User;
+                    var orgId = context.User.FindFirst("organization_id")?.Value;
+                    var caller = new CallerContext(userId, role, orgId);
+                    var lang = await userService.GetUserSettingAsync(userId, UserSetting.PreferredLanguage, caller);
+                    if (lang is not null)
+                    {
+                        context.Response.Cookies.Append(
+                            CookieRequestCultureProvider.DefaultCookieName,
+                            CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(lang)),
+                            new CookieOptions { Expires = DateTimeOffset.UtcNow.AddYears(1), IsEssential = true });
+                        context.Response.Redirect(context.Request.Path + context.Request.QueryString);
+                        return;
+                    }
+
+                    if (noStoredLanguageCacheDuration > TimeSpan.Zero)
+                        cache.Set(cacheKey, true, noStoredLanguageCacheDuration);
                 }
             }
         }

--- a/GospelPresenter/GospelPresenter.Web/Program.cs
+++ b/GospelPresenter/GospelPresenter.Web/Program.cs
@@ -20,6 +20,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 using Prometheus;
 using System.Security.Claims;
 using Serilog;
@@ -85,6 +87,12 @@ try
                 options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
                 options.Cookie.SameSite = SameSiteMode.Lax;
                 options.LoginPath = "/login";
+
+                // Reject the cookie of a user whose account no longer exists. The circuit-level
+                // check in RevalidatingAuthStateProvider only runs once a minute and starts over
+                // on every reload, so without this a deleted user keeps a usable window until the
+                // cookie expires (SessionTimeoutMinutes, four hours by default).
+                options.Events.OnValidatePrincipal = RejectDeletedUser;
             });
 
         if (oidcConfigured)
@@ -174,7 +182,12 @@ try
     {
         Log.Warning("No authentication provider configured — using mock authentication");
         builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-            .AddCookie(options => { options.LoginPath = "/mock-login"; });
+            .AddCookie(options =>
+            {
+                options.LoginPath = "/mock-login";
+                // Same session rule as the real providers: a deleted account stops working here too.
+                options.Events.OnValidatePrincipal = RejectDeletedUser;
+            });
         builder.Services.AddScoped<AuthenticationStateProvider, MockAuthenticationStateProvider>();
         builder.Services.AddSingleton<IAuthProviderService, MockAuthProviderService>();
     }
@@ -229,6 +242,7 @@ try
             opt.UseSqlite("Data Source=gospelpresenter-mock.db"));
     }
 
+    builder.Services.AddMemoryCache();
     builder.Services.AddScoped<IPresentationService, PresentationService>();
     builder.Services.AddSingleton<ISongService, SongService>();
     builder.Services.AddSingleton<IBibleService, BibleService>();
@@ -776,6 +790,54 @@ static string? ResolveScheme(string? provider, IAuthProviderService authProvider
     return null;
 }
 
+static async Task RejectDeletedUser(CookieValidatePrincipalContext context)
+{
+    var userId = context.Principal?.FindFirstValue("user_id");
+    if (string.IsNullOrEmpty(userId))
+        return;
+
+    var services = context.HttpContext.RequestServices;
+    var cache = services.GetRequiredService<IMemoryCache>();
+    var cacheKey = $"user-exists:{userId}";
+    var cacheDuration = TimeSpan.FromSeconds(
+        services.GetRequiredService<IOptions<Settings>>().Value.SessionRevalidationCacheSeconds);
+
+    // This event fires for every request carrying the cookie — including each static asset, since
+    // UseAuthentication runs before the static-file endpoints. Caching the "still exists" answer
+    // keeps one page load to a single query instead of one per file. Only the positive answer is
+    // cached: a rejected user is signed out on the spot, so there is nothing to remember.
+    var cachingEnabled = cacheDuration > TimeSpan.Zero;
+    if (cachingEnabled && cache.TryGetValue(cacheKey, out _))
+        return;
+
+    var userService = services.GetRequiredService<IUserService>();
+    try
+    {
+        if (await userService.UserExistsAsync(userId, context.HttpContext.RequestAborted))
+        {
+            if (cachingEnabled)
+                cache.Set(cacheKey, true, cacheDuration);
+            return;
+        }
+    }
+    catch (OperationCanceledException)
+    {
+        // The client went away mid-request; there is no session left to protect.
+        return;
+    }
+    catch (Exception ex)
+    {
+        // Keep the session if the database is unreachable — signing everyone out during a database
+        // blip would interrupt a service in progress, and the app cannot show content without it.
+        Log.Warning(ex, "Could not verify that user {UserId} still exists; keeping the session", userId);
+        return;
+    }
+
+    Log.Information("Rejecting session for user {UserId}: the account no longer exists", userId);
+    context.RejectPrincipal();
+    await context.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+}
+
 static async Task HandleAuthenticatedUser(
     HttpContext httpContext,
     ClaimsPrincipal? principal,
@@ -863,3 +925,6 @@ static async Task<byte[]?> DownloadImage(IHttpClientFactory httpClientFactory, s
         return null;
     }
 }
+
+// Exposed so the integration tests can boot the real application through WebApplicationFactory.
+public partial class Program;

--- a/GospelPresenter/GospelPresenter.Web/Services/RevalidatingAuthStateProvider.cs
+++ b/GospelPresenter/GospelPresenter.Web/Services/RevalidatingAuthStateProvider.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using GospelPresenter.Shared.Services;
 using GospelPresenter.Web.Configuration;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Server;
@@ -8,32 +9,69 @@ namespace GospelPresenter.Web.Services;
 
 /// <summary>
 /// Periodically revalidates the authentication state within Blazor Server circuits.
-/// Checks the auth_time claim against the configured session timeout to detect expired sessions,
-/// since the persistent WebSocket connection would otherwise keep the user "logged in" in the UI
-/// even after the cookie expires.
+/// The persistent WebSocket connection would otherwise keep the user "logged in" in the UI
+/// even after their access should have ended, so two things are checked:
+/// the auth_time claim against the configured session timeout (an expired cookie), and whether
+/// the user account still exists (a deleted user must lose access without waiting for the timeout).
 /// </summary>
 public class RevalidatingAuthStateProvider(
     ILoggerFactory loggerFactory,
-    IOptions<Settings> settings)
+    IOptions<Settings> settings,
+    IUserService userService)
     : RevalidatingServerAuthenticationStateProvider(loggerFactory)
 {
+    private readonly ILogger<RevalidatingAuthStateProvider> logger =
+        loggerFactory.CreateLogger<RevalidatingAuthStateProvider>();
+
     protected override TimeSpan RevalidationInterval => TimeSpan.FromMinutes(1);
 
-    protected override Task<bool> ValidateAuthenticationStateAsync(
+    protected override async Task<bool> ValidateAuthenticationStateAsync(
         AuthenticationState authenticationState, CancellationToken cancellationToken)
     {
         var user = authenticationState.User;
         if (user.Identity?.IsAuthenticated != true)
-            return Task.FromResult(false);
+            return false;
 
+        if (IsSessionExpired(user))
+            return false;
+
+        return await UserStillExistsAsync(user, cancellationToken);
+    }
+
+    private bool IsSessionExpired(ClaimsPrincipal user)
+    {
         var authTimeClaim = user.FindFirstValue("auth_time");
         if (authTimeClaim == null || !long.TryParse(authTimeClaim, out var unixSeconds))
-            return Task.FromResult(true);
+            return false;
 
         var authTime = DateTimeOffset.FromUnixTimeSeconds(unixSeconds);
         var elapsed = DateTimeOffset.UtcNow - authTime;
         var timeout = TimeSpan.FromMinutes(settings.Value.SessionTimeoutMinutes);
 
-        return Task.FromResult(elapsed < timeout);
+        return elapsed >= timeout;
+    }
+
+    private async Task<bool> UserStillExistsAsync(ClaimsPrincipal user, CancellationToken cancellationToken)
+    {
+        var userId = user.FindFirstValue("user_id");
+        if (string.IsNullOrEmpty(userId))
+            return true;
+
+        try
+        {
+            var exists = await userService.UserExistsAsync(userId, cancellationToken);
+            if (!exists)
+                logger.LogInformation("Ending session for user {UserId}: the account no longer exists.", userId);
+
+            return exists;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Keep the session alive if the database is unreachable. Signing everyone out during a
+            // database blip would interrupt a service in progress, and without the database the app
+            // cannot show any content anyway — so an unverified session gains nothing meanwhile.
+            logger.LogWarning(ex, "Could not verify that user {UserId} still exists; keeping the session.", userId);
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Two pieces of middleware run for every authenticated request — and because they sit before the static-file endpoints, they run for every CSS file, script, font and image too. One of them was a correctness hole, the other a cost. Both are fixed here.

## 1. Deleted users kept their session

Deleting a user had no effect on their live session. The authentication cookie is self-contained and lasts `SessionTimeoutMinutes` (four hours by default), and the Blazor circuit only checked the `auth_time` claim — so a removed account kept working until the cookie happened to expire.

An admin could already delete a user (`DeleteUserAsync`, gated on `ManageUsers`), so this closed a hole that existed rather than adding a feature.

The account is now verified in both places a session survives:

- **`RevalidatingAuthStateProvider`** already ran once a minute inside every circuit to check the session timeout. It now also confirms the user still exists.
- **`OnValidatePrincipal`** rejects the cookie, so reloading the page cannot buy another minute before the circuit check catches up.

A deleted account stops working within 30 seconds on plain requests and 60 seconds in an open circuit.

Mock mode gets the same rule. That is also what makes it testable: the real providers need Google or OIDC, so mock mode is the only sign-in an integration test can perform.

## 2. The language lookup ran on every request

A user who has never chosen a language had nothing stored to find, but the lookup ran again on every request — the default state for every new user. The miss is now remembered.

Choosing a language is unaffected: `/culture` writes the culture cookie in the same response as it stores the setting, and a browser holding that cookie never reaches the lookup at all. Writing the cookie with a fallback culture instead would have removed the query entirely, but it would also pin the user to one culture and silently disable the documented `Accept-Language` default.

Moving the middleware after `MapStaticAssets()` does **not** help, which was measured rather than assumed: a request for a static file cost the same two queries either way. `Map` registers endpoints, and the endpoint-executing middleware is appended to the very end of the pipeline, so every `app.Use` runs before any endpoint regardless of call order.

## Caching

Both fixes cache their answer per user — `SessionRevalidationCacheSeconds` (30) and `PreferredLanguageCacheSeconds` (300). Without that, the session check alone would have turned one page load into one database query per file. Net effect, measured: **a static asset request now costs zero database queries.**

## Deliberate choices

- **Fail open on database errors.** Signing everyone out during a database blip would interrupt a service in progress, and the app cannot show any content without the database anyway, so an unverified session gains nothing meanwhile.
- **Deletion, not deactivation.** This only ends sessions for accounts that are gone. A reversible `IsActive` / "sign out everywhere" pair is a separate change.

## Tests

Seven integration tests boot the application in-process against SQLite and count SQL commands with an EF interceptor:

- repeated requests revalidate the account at most once — and exactly ten times with the cache disabled, so the first test cannot pass vacuously
- the language setting is looked up at most once — likewise guarded by an uncached variant
- a user who does have a stored language still gets their culture cookie restored
- a request after deletion lands on the login page, and a request with a valid session reaches the application
- ten requests for a static file cost exactly zero database queries

The guard tests earned their place: they failed the first version of the fixture, where the authentication cookie never reached the client and every other test passed while the session was broken.

Also five unit tests for `UserExistsAsync`. Full suite: 215 unit, 11 integration, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)